### PR TITLE
Spell correction (Enteties -> Entities)

### DIFF
--- a/lib/fortnox/api/customer.rb
+++ b/lib/fortnox/api/customer.rb
@@ -4,7 +4,7 @@ require "fortnox/api/models/customer/validator"
 
 module Fortnox
   module API
-    class Customer < Fortnox::API::Enteties::Customer
+    class Customer < Fortnox::API::Entities::Customer
 
       def valid?
         Fortnox::API::Validators::Customer.validate( self )

--- a/lib/fortnox/api/models/customer/entity.rb
+++ b/lib/fortnox/api/models/customer/entity.rb
@@ -2,7 +2,7 @@ require "fortnox/api/models/entity/base"
 
 module Fortnox
   module API
-    module Enteties
+    module Entities
       class Customer < Fortnox::API::Entities::Base
 
         #Url	Direct URL to the record

--- a/lib/fortnox/api/models/customer/repository.rb
+++ b/lib/fortnox/api/models/customer/repository.rb
@@ -33,7 +33,7 @@ module Fortnox
 
         def instansiate( hash )
           hash[ 'new' ] = false
-          Fortnox::API::Enteties::Customer.new( hash )
+          Fortnox::API::Entities::Customer.new( hash )
         end
 
       end

--- a/spec/fortnox/api/models/customer/repository_spec.rb
+++ b/spec/fortnox/api/models/customer/repository_spec.rb
@@ -20,7 +20,7 @@ describe Fortnox::API::Repositories::Customer do
 
   describe '#save' do
     context 'unsaved, new customer' do
-      let( :customer ){ Fortnox::API::Enteties::Customer.new( unsaved: false ) }
+      let( :customer ){ Fortnox::API::Entities::Customer.new( unsaved: false ) }
 
       it 'doesn\'t make an API request' do
         expect( repository ).not_to receive( :save_new )

--- a/spec/fortnox/api/models/customer/validator_spec.rb
+++ b/spec/fortnox/api/models/customer/validator_spec.rb
@@ -7,7 +7,7 @@ describe Fortnox::API::Validators::Customer do
 
   describe '.validate' do
     context 'Customer with valid, simple attributes' do
-      let( :customer ){ Fortnox::API::Enteties::Customer.new( name: 'Test' ) }
+      let( :customer ){ Fortnox::API::Entities::Customer.new( name: 'Test' ) }
 
       it 'is valid' do
         expect( validator.validate( customer )).to eql( true )
@@ -15,7 +15,7 @@ describe Fortnox::API::Validators::Customer do
     end
 
     context 'Customer with invalid sales_account' do
-      let( :customer ){ Fortnox::API::Enteties::Customer.new( sales_account: 99999 )}
+      let( :customer ){ Fortnox::API::Entities::Customer.new( sales_account: 99999 )}
 
       it 'is invalid' do
         expect( validator.validate( customer )).to eql( false )


### PR DESCRIPTION
The module `Entities` was incorrectly named `Enteties` in some files.