### PR TITLE
Customer validator spec uses shared context

### DIFF
--- a/lib/fortnox/api/validators/customer.rb
+++ b/lib/fortnox/api/validators/customer.rb
@@ -13,9 +13,6 @@ module Fortnox
 
           validates_presence_of :name
 
-          validates_length_of :currency,      length: 3,  if: :currency?
-          validates_length_of :country_code,  length: 2,  if: :country_code?
-
           validates_inclusion_of :sales_account,  within: (0..9999),               if: :sales_account?
           validates_inclusion_of :type,           within: ['PRIVATE', 'COMPANY'],  if: :type?
           validates_inclusion_of :vat_type,       within: VAT_TYPES,               if: :vat_type?

--- a/spec/fortnox/api/validators/context.rb
+++ b/spec/fortnox/api/validators/context.rb
@@ -46,7 +46,7 @@ shared_context 'validator context' do
     end
   end
 
-  shared_examples_for 'validates inclusion of' do |attribute, min_value, max_value|
+  shared_examples_for 'validates inclusion of number' do |attribute, min_value, max_value|
     context "with #{attribute} set to" do
       context "minimum value (#{min_value})" do
         include_examples 'behaves like valid', attribute, min_value
@@ -63,6 +63,34 @@ shared_context 'validator context' do
       context "too big value (#{max_value + 1})" do
         include_examples 'behaves like invalid', attribute, max_value + 1, :inclusion
       end
+    end
+  end
+
+  shared_examples_for 'validates inclusion of string' do |attribute, valid_strings|
+    context "with #{attribute} set to" do
+      valid_strings.each do |valid_string|
+        context "\"#{valid_string}\"" do
+          include_examples 'behaves like valid', attribute, valid_string
+        end
+      end
+
+      context 'a string not allowed' do
+        # Try first valid string and append nonsense
+        include_examples 'behaves like invalid',
+                         attribute,
+                         valid_strings.first + '123nonsense123',
+                         :inclusion
+      end
+    end
+  end
+
+  shared_examples_for 'required attributes' do |model_class|
+    context 'with required attributes' do
+      it{ is_expected.to be_valid( valid_model ) }
+    end
+
+    context 'without required attributes' do
+      it{ is_expected.to_not be_valid( model_class.new ) }
     end
   end
 end

--- a/spec/fortnox/api/validators/customer_spec.rb
+++ b/spec/fortnox/api/validators/customer_spec.rb
@@ -1,33 +1,23 @@
 require 'spec_helper'
-require 'fortnox/api/validators/customer'
 require 'fortnox/api/models/customer'
+require 'fortnox/api/validators/context'
+require 'fortnox/api/validators/customer'
 
 describe Fortnox::API::Validator::Customer do
-  let( :validator ){ Fortnox::API::Validator::Customer }
+  let( :model_class ){ Fortnox::API::Model::Customer }
 
-  describe '.validate' do
-    context 'Customer with valid, simple attributes' do
-      let( :customer ){ Fortnox::API::Model::Customer.new( name: 'Test' ) }
-
-      it 'is valid' do
-        expect( validator.validate( customer )).to eql( true )
-      end
-    end
-
-    context 'Customer with invalid sales_account' do
-      let( :customer ){ Fortnox::API::Model::Customer.new( name: 'Test', sales_account: 99999 ) }
-
-      it 'is invalid' do
-        expect( validator.validate( customer )).to eql( false )
-      end
-
-      it 'includes "sales_account" in violations' do
-        validator.validate( customer )
-
-        expect( validator.violations.any?{ |v| v.rule.attribute_name == :sales_account }).to eql( true )
-        expect( validator.violations.any?{ |v| v.rule.type == :inclusion }).to eql( true )
-      end
-    end
+  include_context 'validator context' do
+    let( :valid_model ){ model_class.new( name: 'A customer' ) }
   end
 
+  describe '.validate Customer' do
+    include_examples 'required attributes', Fortnox::API::Model::Customer
+
+    include_examples 'validates inclusion of number', :sales_account, 0, 9999.0
+
+    TYPES = ['PRIVATE', 'COMPANY']
+    VAT_TYPES = ['SEVAT', 'SEREVERSEDVAT', 'EUREVERSEDVAT', 'EUVAT', 'EXPORT']
+    include_examples 'validates inclusion of string', :type, TYPES
+    include_examples 'validates inclusion of string', :vat_type, VAT_TYPES
+  end
 end

--- a/spec/fortnox/api/validators/invoice_spec.rb
+++ b/spec/fortnox/api/validators/invoice_spec.rb
@@ -11,13 +11,7 @@ describe Fortnox::API::Validator::Invoice do
   end
 
   describe '.validate Invoice' do
-    context 'with required attributes' do
-      it{ is_expected.to be_valid( valid_model ) }
-    end
-
-    context 'without required attributes' do
-      it{ is_expected.to_not be_valid( model_class.new ) }
-    end
+    include_examples 'required attributes', Fortnox::API::Model::Invoice
 
     include_examples 'validates length of string', :address1, 1024
     include_examples 'validates length of string', :address2, 1024
@@ -32,9 +26,9 @@ describe Fortnox::API::Validator::Invoice do
     include_examples 'validates length of string', :your_reference, 50
     include_examples 'validates length of string', :zip_code, 1024
 
-    include_examples 'validates inclusion of', :administration_fee, 0, 99_999_999_999.0
-    include_examples 'validates inclusion of', :currency_rate, 0, 999_999_999_999_999.0
-    include_examples 'validates inclusion of', :currency_unit, 0, 999_999_999_999_999.0
-    include_examples 'validates inclusion of', :freight, 0, 99_999_999_999.0
+    include_examples 'validates inclusion of number', :administration_fee, 0, 99_999_999_999.0
+    include_examples 'validates inclusion of number', :currency_rate, 0, 999_999_999_999_999.0
+    include_examples 'validates inclusion of number', :currency_unit, 0, 999_999_999_999_999.0
+    include_examples 'validates inclusion of number', :freight, 0, 99_999_999_999.0
   end
 end

--- a/spec/fortnox/api/validators/row_spec.rb
+++ b/spec/fortnox/api/validators/row_spec.rb
@@ -16,10 +16,10 @@ describe Fortnox::API::Validator::Row do
     include_examples 'validates length of string', :article_number, 50
     include_examples 'validates length of string', :description, 50
 
-    include_examples 'validates inclusion of', :account_number, 0, 9999
-    include_examples 'validates inclusion of', :delivered_quantity, 0, 9_999_999_999_999.0
-    include_examples 'validates inclusion of', :discount, 0, 99_999_999_999.0
-    include_examples 'validates inclusion of', :house_work_hours_to_report, 0, 99_999
-    include_examples 'validates inclusion of', :price, 0, 99_999_999_999.0
+    include_examples 'validates inclusion of number', :account_number, 0, 9999
+    include_examples 'validates inclusion of number', :delivered_quantity, 0, 9_999_999_999_999.0
+    include_examples 'validates inclusion of number', :discount, 0, 99_999_999_999.0
+    include_examples 'validates inclusion of number', :house_work_hours_to_report, 0, 99_999
+    include_examples 'validates inclusion of number', :price, 0, 99_999_999_999.0
   end
 end


### PR DESCRIPTION
When introducing shared context to the validators/customer_spec,
I found that validators for currency and country_code was
not working. These are separate attributes and are already validated.
For instance, if assigning 'A' to currency, it is still nil and no
validations are added. We must either change the attribute classes
and add the error there, or skip error messages for these attributes.

Additionally, validators context is updated with a shared examples
for validating inclusion of strings and the former shared examples
'validate inclusion of' is now called 'validate inclusion of number'.