### PR TITLE
Flaky tests

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,11 +6,12 @@ engines:
     enabled: true
     config:
       languages:
-      - ruby
-      exclude_paths:
-      # Exclude spec/ from duplication engine since too dry specs
-      # reduces readability.
-      - spec/
+        ruby:
+          mass_threshold: 20
+          exclude_paths:
+            # Exclude spec/ from duplication engine since too dry specs
+            # reduces readability.
+            - spec/
   eslint:
     enabled: true
   fixme:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,6 +7,10 @@ engines:
     config:
       languages:
       - ruby
+      exclude_paths:
+      # Exclude spec/ from duplication engine since too dry specs
+      # reduces readability.
+      - spec/
   eslint:
     enabled: true
   fixme:

--- a/lib/fortnox/api/models/attributes/country_code.rb
+++ b/lib/fortnox/api/models/attributes/country_code.rb
@@ -6,15 +6,12 @@ module Fortnox
       module Attribute
         module CountryCode
 
-          ALLOWED = ['AF','AX','AL','DZ','AS','AD','AO','AI','AQ','AG','AR','AM','AW','AU','AT','AZ','BS','BH','BD','BB','BY','BE','BZ','BJ','BM','BT','BO','BQ','BA','BW','BV','BR','IO','BN','BG','BF','BI','CV','KH','CM','CA','KY','CF','TD','CL','CN','CX','CC','CO','KM','CG','CD','CK','CR','CI','HR','CU','CW','CY','CZ','DK','DJ','DM','DO','EC','EG','SV','GQ','ER','EE','ET','FK','FO','FJ','FI','FR','GF','PF','TF','GA','GM','GE','DE','GH','GI','GR','GL','GD','GP','GU','GT','GG','GN','GW','GY','HT','HM','VA','HN','HK','HU','IS','IN','ID','IR','IQ','IE','IM','IL','IT','JM','JP','JE','JO','KZ','KE','KI','KP','KR','KW','KG','LA','LV','LB','LS','LR','LY','LI','LT','LU','MO','MK','MG','MW','MY','MV','ML','MT','MH','MQ','MR','MU','YT','MX','FM','MD','MC','MN','ME','MS','MA','MZ','MM','NA','NR','NP','NL','NC','NZ','NI','NE','NG','NU','NF','MP','NO','OM','PK','PW','PS','PA','PG','PY','PE','PH','PN','PL','PT','PR','QA','RE','RO','RU','RW','BL','SH','KN','LC','MF','PM','VC','WS','SM','ST','SA','SN','RS','SC','SL','SG','SX','SK','SI','SB','SO','ZA','GS','SS','ES','LK','SD','SR','SJ','SZ','SE','CH','SY','TW','TJ','TZ','TH','TL','TG','TK','TO','TT','TN','TR','TM','TC','TV','UG','UA','AE','GB','US','UM','UY','UZ','VU','VE','VN','VG','VI','WF','EH','YE','ZM','ZW']
-
           include Virtus.module
 
           attribute :country_code, String
 
           def country_code=( raw_country_code )
-            country_code = raw_country_code.upcase[0...2]
-            super country_code
+            super raw_country_code.upcase[0...2]
           end
 
         end

--- a/lib/fortnox/api/models/attributes/currency.rb
+++ b/lib/fortnox/api/models/attributes/currency.rb
@@ -6,15 +6,12 @@ module Fortnox
       module Attribute
         module Currency
 
-          ALLOWED = ['AED','AFN','ALL','AMD','ANG','AOA','ARS','AUD','AWG','AZN','BAM','BBD','BDT','BGN','BHD','BIF','BMD','BND','BOB','BOV','BRL','BSD','BTN','BWP','BYR','BZD','CAD','CDF','CHE','CHF','CHW','CLF','CLP','CNY','COP','COU','CRC','CUP','CVE','CZK','DJF','DKK','DOP','DZD','EGP','ERN','ETB','EUR','FJD','FKP','GBP','GEL','GHS','GIP','GMD','GNF','GTQ','GYD','HKD','HNL','HRK','HTG','HUF','IDR','ILS','INR','IQD','IRR','ISK','JMD','JOD','JPY','KES','KGS','KHR','KUR','KMF','KPW','KRW','KWD','KYD','KZT','LAK','LBP','LKR','LRD','LSL','LYD','MAD','MDL','MGA','MKD','MMK','MNT','MOP','MRO','MUR','MVR','MWK','MXN','MXV','MYR','MZN','NAD','NGN','NIO','NOK','NPR','NZD','OMR','PAB','PEN','PGK','PHP','PKR','PLN','PYG','QAR','RON','RSD','RUB','RWF','SAR','SBD','SCR','SDG','SEK','SGD','SHP','SLL','SOS','SRD','SSP','STD','SYP','SZL','THB','TJS','TMM','TND','TOP','TRY','TTD','TWD','TZS','UAH','UGX','USD','USN','USS','UYU','UZS','VEF','VND','VUV','WST','XAF','XAG','XAU','XBA','XBB','XBC','XBD','XCD','XDR','XFU','XOF','XPD','XPF','XPT','XTS','XXX','YER','ZAR','ZMK','ZWD']
-
           include Virtus.module
 
           attribute :currency, String
 
           def currency=( raw_currency )
-            currency = raw_currency.upcase[0...3]
-            super currency
+            super raw_currency.upcase[0...3]
           end
 
         end

--- a/lib/fortnox/api/validators/attributes/country_code.rb
+++ b/lib/fortnox/api/validators/attributes/country_code.rb
@@ -1,0 +1,42 @@
+require "fortnox/api/validators/base"
+
+module Fortnox
+  module API
+    module Validator
+      module Attribute
+        module CountryCode
+
+          COUNTRY_CODES = [
+            'AF','AX','AL','DZ','AS','AD','AO','AI','AQ','AG','AR','AM','AW',
+            'AU','AT','AZ','BS','BH','BD','BB','BY','BE','BZ','BJ','BM','BT',
+            'BO','BQ','BA','BW','BV','BR','IO','BN','BG','BF','BI','CV','KH',
+            'CM','CA','KY','CF','TD','CL','CN','CX','CC','CO','KM','CG','CD',
+            'CK','CR','CI','HR','CU','CW','CY','CZ','DK','DJ','DM','DO','EC',
+            'EG','SV','GQ','ER','EE','ET','FK','FO','FJ','FI','FR','GF','PF',
+            'TF','GA','GM','GE','DE','GH','GI','GR','GL','GD','GP','GU','GT',
+            'GG','GN','GW','GY','HT','HM','VA','HN','HK','HU','IS','IN','ID',
+            'IR','IQ','IE','IM','IL','IT','JM','JP','JE','JO','KZ','KE','KI',
+            'KP','KR','KW','KG','LA','LV','LB','LS','LR','LY','LI','LT','LU',
+            'MO','MK','MG','MW','MY','MV','ML','MT','MH','MQ','MR','MU','YT',
+            'MX','FM','MD','MC','MN','ME','MS','MA','MZ','MM','NA','NR','NP',
+            'NL','NC','NZ','NI','NE','NG','NU','NF','MP','NO','OM','PK','PW',
+            'PS','PA','PG','PY','PE','PH','PN','PL','PT','PR','QA','RE','RO',
+            'RU','RW','BL','SH','KN','LC','MF','PM','VC','WS','SM','ST','SA',
+            'SN','RS','SC','SL','SG','SX','SK','SI','SB','SO','ZA','GS','SS',
+            'ES','LK','SD','SR','SJ','SZ','SE','CH','SY','TW','TJ','TZ','TH',
+            'TL','TG','TK','TO','TT','TN','TR','TM','TC','TV','UG','UA','AE',
+            'GB','US','UM','UY','UZ','VU','VE','VN','VG','VI','WF','EH','YE',
+            'ZM','ZW'
+          ]
+
+          def self.included( other )
+            other.using_validations do
+              validates_inclusion_of :country_code, within: COUNTRY_CODES, if: :country_code?
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/fortnox/api/validators/attributes/currency.rb
+++ b/lib/fortnox/api/validators/attributes/currency.rb
@@ -1,0 +1,38 @@
+require "fortnox/api/validators/base"
+
+module Fortnox
+  module API
+    module Validator
+      module Attribute
+        module Currency
+
+          CURRENCIES = [
+            'AED','AFN','ALL','AMD','ANG','AOA','ARS','AUD','AWG','AZN','BAM',
+            'BBD','BDT','BGN','BHD','BIF','BMD','BND','BOB','BOV','BRL','BSD',
+            'BTN','BWP','BYR','BZD','CAD','CDF','CHE','CHF','CHW','CLF','CLP',
+            'CNY','COP','COU','CRC','CUP','CVE','CZK','DJF','DKK','DOP','DZD',
+            'EGP','ERN','ETB','EUR','FJD','FKP','GBP','GEL','GHS','GIP','GMD',
+            'GNF','GTQ','GYD','HKD','HNL','HRK','HTG','HUF','IDR','ILS','INR',
+            'IQD','IRR','ISK','JMD','JOD','JPY','KES','KGS','KHR','KUR','KMF',
+            'KPW','KRW','KWD','KYD','KZT','LAK','LBP','LKR','LRD','LSL','LYD',
+            'MAD','MDL','MGA','MKD','MMK','MNT','MOP','MRO','MUR','MVR','MWK',
+            'MXN','MXV','MYR','MZN','NAD','NGN','NIO','NOK','NPR','NZD','OMR',
+            'PAB','PEN','PGK','PHP','PKR','PLN','PYG','QAR','RON','RSD','RUB',
+            'RWF','SAR','SBD','SCR','SDG','SEK','SGD','SHP','SLL','SOS','SRD',
+            'SSP','STD','SYP','SZL','THB','TJS','TMM','TND','TOP','TRY','TTD',
+            'TWD','TZS','UAH','UGX','USD','USN','USS','UYU','UZS','VEF','VND',
+            'VUV','WST','XAF','XAG','XAU','XBA','XBB','XBC','XBD','XCD','XDR',
+            'XFU','XOF','XPD','XPF','XPT','XTS','XXX','YER','ZAR','ZMK','ZWD'
+          ]
+
+          def self.included( other )
+            other.using_validations do
+              validates_inclusion_of :currency, within: CURRENCIES, if: :currency?
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/spec/fortnox/api/models/attributes/country_code_spec.rb
+++ b/spec/fortnox/api/models/attributes/country_code_spec.rb
@@ -17,11 +17,6 @@ describe Fortnox::API::Model::Attribute::CountryCode do
         expect( test_case.country_code ).to eql( nil )
       end
 
-      it 'upcases lower case' do
-        test_case = Model.new( country_code: 'se' )
-        expect( test_case.country_code ).to eql( 'SE' )
-      end
-
       it 'truncates to two characters' do
         test_case = Model.new( country_code: 'sek' )
         expect( test_case.country_code ).to eql( 'SE' )

--- a/spec/fortnox/api/models/attributes/country_code_spec.rb
+++ b/spec/fortnox/api/models/attributes/country_code_spec.rb
@@ -3,7 +3,7 @@ require 'fortnox/api/models/attributes/country_code'
 
 describe Fortnox::API::Model::Attribute::CountryCode do
 
-  using_test_classes do
+  using_test_class do
     class Model
       include Virtus.model
       include Fortnox::API::Model::Attribute::CountryCode

--- a/spec/fortnox/api/models/attributes/country_code_spec.rb
+++ b/spec/fortnox/api/models/attributes/country_code_spec.rb
@@ -3,25 +3,27 @@ require 'fortnox/api/models/attributes/country_code'
 
 describe Fortnox::API::Model::Attribute::CountryCode do
 
-  class TestCase
-    include Virtus.model
-    include Fortnox::API::Model::Attribute::CountryCode
+  using_test_classes do
+    class Model
+      include Virtus.model
+      include Fortnox::API::Model::Attribute::CountryCode
+    end
   end
 
   describe '.new' do
     context 'with country code' do
       it 'ignores empty values' do
-        test_case = TestCase.new()
+        test_case = Model.new()
         expect( test_case.country_code ).to eql( nil )
       end
 
       it 'upcases lower case' do
-        test_case = TestCase.new( country_code: 'se' )
+        test_case = Model.new( country_code: 'se' )
         expect( test_case.country_code ).to eql( 'SE' )
       end
 
       it 'truncates to two characters' do
-        test_case = TestCase.new( country_code: 'sek' )
+        test_case = Model.new( country_code: 'sek' )
         expect( test_case.country_code ).to eql( 'SE' )
       end
     end

--- a/spec/fortnox/api/models/attributes/currency_spec.rb
+++ b/spec/fortnox/api/models/attributes/currency_spec.rb
@@ -3,7 +3,7 @@ require 'fortnox/api/models/attributes/currency'
 
 describe Fortnox::API::Model::Attribute::Currency do
 
-  using_test_classes do
+  using_test_class do
     class Model
       include Virtus.model
       include Fortnox::API::Model::Attribute::Currency

--- a/spec/fortnox/api/models/attributes/currency_spec.rb
+++ b/spec/fortnox/api/models/attributes/currency_spec.rb
@@ -3,33 +3,37 @@ require 'fortnox/api/models/attributes/currency'
 
 describe Fortnox::API::Model::Attribute::Currency do
 
-  let( :model ){
-    class Model
+  before(:all) do
+    class TestModel
       include Virtus.model
       include Fortnox::API::Model::Attribute::Currency
     end
-  }
+  end
+
+  after(:all) do
+    Object.send(:remove_const, :TestModel)
+  end
 
   subject{ instance.currency }
 
   describe '.new' do
     context 'with empty country code' do
-      let( :instance ){ model.new() }
+      let( :instance ){ TestModel.new() }
       it{ is_expected.to eql( nil ) }
     end
 
     context 'with lowercase country code' do
-      let( :instance ){ model.new( currency: 'sek' ) }
+      let( :instance ){ TestModel.new( currency: 'sek' ) }
       it{ is_expected.to eql( 'SEK' ) }
     end
 
     context 'with too long country code' do
-      let( :instance ){ model.new( currency: 'usdollar' ) }
+      let( :instance ){ TestModel.new( currency: 'usdollar' ) }
       it{ is_expected.to eql( 'USD' ) }
     end
 
     context 'with too long country code' do
-      let( :instance ){ model.new( currency: 'dollaridoos' ) }
+      let( :instance ){ TestModel.new( currency: 'dollaridoos' ) }
       it{ is_expected.to eql( 'DOL' ) }
     end
   end

--- a/spec/fortnox/api/models/attributes/currency_spec.rb
+++ b/spec/fortnox/api/models/attributes/currency_spec.rb
@@ -18,19 +18,9 @@ describe Fortnox::API::Model::Attribute::Currency do
       it{ is_expected.to eql( nil ) }
     end
 
-    context 'with lowercase country code' do
-      let( :instance ){ Model.new( currency: 'sek' ) }
-      it{ is_expected.to eql( 'SEK' ) }
-    end
-
     context 'with too long country code' do
       let( :instance ){ Model.new( currency: 'usdollar' ) }
       it{ is_expected.to eql( 'USD' ) }
-    end
-
-    context 'with too long country code' do
-      let( :instance ){ Model.new( currency: 'dollaridoos' ) }
-      it{ is_expected.to eql( 'DOL' ) }
     end
   end
 

--- a/spec/fortnox/api/models/attributes/currency_spec.rb
+++ b/spec/fortnox/api/models/attributes/currency_spec.rb
@@ -3,27 +3,34 @@ require 'fortnox/api/models/attributes/currency'
 
 describe Fortnox::API::Model::Attribute::Currency do
 
-  class TestCase
-    include Virtus.model
-    include Fortnox::API::Model::Attribute::Currency
-  end
+  let( :model ){
+    class Model
+      include Virtus.model
+      include Fortnox::API::Model::Attribute::Currency
+    end
+  }
+
+  subject{ instance.currency }
 
   describe '.new' do
-    context 'with country code' do
-      it 'ignores empty values' do
-        test_case = TestCase.new()
-        expect( test_case.currency ).to eql( nil )
-      end
+    context 'with empty country code' do
+      let( :instance ){ model.new() }
+      it{ is_expected.to eql( nil ) }
+    end
 
-      it 'upcases lower case' do
-        test_case = TestCase.new( currency: 'sek' )
-        expect( test_case.currency ).to eql( 'SEK' )
-      end
+    context 'with lowercase country code' do
+      let( :instance ){ model.new( currency: 'sek' ) }
+      it{ is_expected.to eql( 'SEK' ) }
+    end
 
-      it 'truncates to two characters' do
-        test_case = TestCase.new( currency: 'usdollar' )
-        expect( test_case.currency ).to eql( 'USD' )
-      end
+    context 'with too long country code' do
+      let( :instance ){ model.new( currency: 'usdollar' ) }
+      it{ is_expected.to eql( 'USD' ) }
+    end
+
+    context 'with too long country code' do
+      let( :instance ){ model.new( currency: 'dollaridoos' ) }
+      it{ is_expected.to eql( 'DOL' ) }
     end
   end
 

--- a/spec/fortnox/api/models/attributes/currency_spec.rb
+++ b/spec/fortnox/api/models/attributes/currency_spec.rb
@@ -3,37 +3,33 @@ require 'fortnox/api/models/attributes/currency'
 
 describe Fortnox::API::Model::Attribute::Currency do
 
-  before(:all) do
-    class TestModel
+  using_test_classes do
+    class Model
       include Virtus.model
       include Fortnox::API::Model::Attribute::Currency
     end
-  end
-
-  after(:all) do
-    Object.send(:remove_const, :TestModel)
   end
 
   subject{ instance.currency }
 
   describe '.new' do
     context 'with empty country code' do
-      let( :instance ){ TestModel.new() }
+      let( :instance ){ Model.new() }
       it{ is_expected.to eql( nil ) }
     end
 
     context 'with lowercase country code' do
-      let( :instance ){ TestModel.new( currency: 'sek' ) }
+      let( :instance ){ Model.new( currency: 'sek' ) }
       it{ is_expected.to eql( 'SEK' ) }
     end
 
     context 'with too long country code' do
-      let( :instance ){ TestModel.new( currency: 'usdollar' ) }
+      let( :instance ){ Model.new( currency: 'usdollar' ) }
       it{ is_expected.to eql( 'USD' ) }
     end
 
     context 'with too long country code' do
-      let( :instance ){ TestModel.new( currency: 'dollaridoos' ) }
+      let( :instance ){ Model.new( currency: 'dollaridoos' ) }
       it{ is_expected.to eql( 'DOL' ) }
     end
   end

--- a/spec/fortnox/api/validators/attributes/country_code_spec.rb
+++ b/spec/fortnox/api/validators/attributes/country_code_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'fortnox/api/models/base'
+require 'fortnox/api/models/attributes/country_code'
+require 'fortnox/api/validators/attributes/country_code'
+
+describe Fortnox::API::Validator::Attribute::CountryCode do
+
+  let( :model ){
+    class Model < Fortnox::API::Model::Base
+      include Fortnox::API::Model::Attribute::CountryCode
+    end
+  }
+
+  let( :validator ){
+    class Validator
+      extend Fortnox::API::Validator::Base
+      include Fortnox::API::Validator::Attribute::CountryCode
+    end
+  }
+
+  describe '.validate' do
+    context 'does not allow bogus country_code value' do
+      let( :instance ){ model.new( country_code: 'aaa' ) }
+      subject{ validator.validate( instance ) }
+      it{ is_expected.to eql( false ) }
+    end
+  end
+
+end

--- a/spec/fortnox/api/validators/attributes/country_code_spec.rb
+++ b/spec/fortnox/api/validators/attributes/country_code_spec.rb
@@ -5,23 +5,26 @@ require 'fortnox/api/validators/attributes/country_code'
 
 describe Fortnox::API::Validator::Attribute::CountryCode do
 
-  let( :model ){
-    class Model < Fortnox::API::Model::Base
+  before(:all) do
+    class TestModel < Fortnox::API::Model::Base
       include Fortnox::API::Model::Attribute::CountryCode
     end
-  }
 
-  let( :validator ){
-    class Validator
+    class TestValidator
       extend Fortnox::API::Validator::Base
       include Fortnox::API::Validator::Attribute::CountryCode
     end
-  }
+  end
+
+  after(:all) do
+    Object.send(:remove_const, :TestModel)
+    Object.send(:remove_const, :TestValidator)
+  end
 
   describe '.validate' do
     context 'does not allow bogus country_code value' do
-      let( :instance ){ model.new( country_code: 'aaa' ) }
-      subject{ validator.validate( instance ) }
+      let( :instance ){ TestModel.new( country_code: 'aaa' ) }
+      subject{ TestValidator.validate( instance ) }
       it{ is_expected.to eql( false ) }
     end
   end

--- a/spec/fortnox/api/validators/attributes/country_code_spec.rb
+++ b/spec/fortnox/api/validators/attributes/country_code_spec.rb
@@ -5,7 +5,7 @@ require 'fortnox/api/validators/attributes/country_code'
 
 describe Fortnox::API::Validator::Attribute::CountryCode do
 
-  before(:all) do
+  using_test_classes do
     class TestModel < Fortnox::API::Model::Base
       include Fortnox::API::Model::Attribute::CountryCode
     end
@@ -14,11 +14,6 @@ describe Fortnox::API::Validator::Attribute::CountryCode do
       extend Fortnox::API::Validator::Base
       include Fortnox::API::Validator::Attribute::CountryCode
     end
-  end
-
-  after(:all) do
-    Object.send(:remove_const, :TestModel)
-    Object.send(:remove_const, :TestValidator)
   end
 
   describe '.validate' do

--- a/spec/fortnox/api/validators/attributes/currency_spec.rb
+++ b/spec/fortnox/api/validators/attributes/currency_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'fortnox/api/models/base'
+require 'fortnox/api/models/attributes/currency'
+require 'fortnox/api/validators/attributes/currency'
+
+describe Fortnox::API::Validator::Attribute::Currency do
+
+  let( :model ){
+    class Model < Fortnox::API::Model::Base
+      include Fortnox::API::Model::Attribute::Currency
+    end
+  }
+
+  let( :validator ){
+    class Validator
+      extend Fortnox::API::Validator::Base
+      include Fortnox::API::Validator::Attribute::Currency
+    end
+  }
+
+  describe '.validate' do
+    context 'model with invalid currency attribute' do
+      let( :instance ){ model.new( currency: '-_-' ) }
+
+      it 'is invalid' do
+        expect( validator.validate( instance )).to eql( false )
+      end
+    end
+  end
+
+end

--- a/spec/fortnox/api/validators/attributes/currency_spec.rb
+++ b/spec/fortnox/api/validators/attributes/currency_spec.rb
@@ -3,23 +3,6 @@ require 'fortnox/api/models/base'
 require 'fortnox/api/models/attributes/currency'
 require 'fortnox/api/validators/attributes/currency'
 
-def using_test_classes &block
-  around( :all ) do |example|
-    classes_before_examples = Object.constants
-
-    yield
-
-    classes_after_examples = Object.constants
-    classes_created_by_block = classes_after_examples - classes_before_examples
-
-    example.run
-
-    classes_created_by_block.each do |klass|
-      Object.send(:remove_const, klass)
-    end
-  end
-end
-
 describe Fortnox::API::Validator::Attribute::Currency do
 
   using_test_classes do

--- a/spec/fortnox/api/validators/attributes/currency_spec.rb
+++ b/spec/fortnox/api/validators/attributes/currency_spec.rb
@@ -5,25 +5,28 @@ require 'fortnox/api/validators/attributes/currency'
 
 describe Fortnox::API::Validator::Attribute::Currency do
 
-  let( :model ){
-    class Model < Fortnox::API::Model::Base
+  before(:all) do
+    class TestModel < Fortnox::API::Model::Base
       include Fortnox::API::Model::Attribute::Currency
     end
-  }
 
-  let( :validator ){
-    class Validator
+    class TestValidator
       extend Fortnox::API::Validator::Base
       include Fortnox::API::Validator::Attribute::Currency
     end
-  }
+  end
+
+  after(:all) do
+    Object.send(:remove_const, :TestModel)
+    Object.send(:remove_const, :TestValidator)
+  end
 
   describe '.validate' do
     context 'model with invalid currency attribute' do
-      let( :instance ){ model.new( currency: '-_-' ) }
+      let( :instance ){ TestModel.new( currency: '-_-' ) }
 
       it 'is invalid' do
-        expect( validator.validate( instance )).to eql( false )
+        expect( TestValidator.validate( instance )).to eql( false )
       end
     end
   end

--- a/spec/fortnox/api/validators/attributes/currency_spec.rb
+++ b/spec/fortnox/api/validators/attributes/currency_spec.rb
@@ -3,30 +3,42 @@ require 'fortnox/api/models/base'
 require 'fortnox/api/models/attributes/currency'
 require 'fortnox/api/validators/attributes/currency'
 
+def using_test_classes &block
+  around( :all ) do |example|
+    classes_before_examples = Object.constants
+
+    yield
+
+    classes_after_examples = Object.constants
+    classes_created_by_block = classes_after_examples - classes_before_examples
+
+    example.run
+
+    classes_created_by_block.each do |klass|
+      Object.send(:remove_const, klass)
+    end
+  end
+end
+
 describe Fortnox::API::Validator::Attribute::Currency do
 
-  before(:all) do
-    class TestModel < Fortnox::API::Model::Base
+  using_test_classes do
+    class Model < Fortnox::API::Model::Base
       include Fortnox::API::Model::Attribute::Currency
     end
 
-    class TestValidator
+    class Validator
       extend Fortnox::API::Validator::Base
       include Fortnox::API::Validator::Attribute::Currency
     end
   end
 
-  after(:all) do
-    Object.send(:remove_const, :TestModel)
-    Object.send(:remove_const, :TestValidator)
-  end
-
   describe '.validate' do
     context 'model with invalid currency attribute' do
-      let( :instance ){ TestModel.new( currency: '-_-' ) }
+      let( :instance ){ Model.new( currency: '-_-' ) }
 
       it 'is invalid' do
-        expect( TestValidator.validate( instance )).to eql( false )
+        expect( Validator.validate( instance )).to eql( false )
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,12 +4,15 @@ require 'webmock/rspec'
 require 'pry'
 require "codeclimate-test-reporter"
 require 'support/matchers'
+require 'support/helpers'
 
 CodeClimate::TestReporter.start
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
+
+  config.extend Helpers
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,1 @@
+Dir[File.expand_path('spec/support/helpers/*.rb')].each{ |file| require file }

--- a/spec/support/helpers/dummy_class_helper.rb
+++ b/spec/support/helpers/dummy_class_helper.rb
@@ -1,5 +1,5 @@
 module Helpers
-  def using_test_classes &block
+  def using_test_classes
     around( :all ) do |example|
       classes_before_examples = Object.constants
 

--- a/spec/support/helpers/dummy_class_helper.rb
+++ b/spec/support/helpers/dummy_class_helper.rb
@@ -1,0 +1,18 @@
+module Helpers
+  def using_test_classes &block
+    around( :all ) do |example|
+      classes_before_examples = Object.constants
+
+      yield
+
+      classes_after_examples = Object.constants
+      classes_created_by_block = classes_after_examples - classes_before_examples
+
+      example.run
+
+      classes_created_by_block.each do |klass|
+        Object.send(:remove_const, klass)
+      end
+    end
+  end
+end

--- a/spec/support/helpers/dummy_class_helper.rb
+++ b/spec/support/helpers/dummy_class_helper.rb
@@ -15,4 +15,6 @@ module Helpers
       end
     end
   end
+
+  alias_method :using_test_class, :using_test_classes
 end


### PR DESCRIPTION
_Reopening of PR https://github.com/my-codeworks/fortnox-api/pull/14 against the correct branch. This was necessary since we changed the branching scheme after the PR was originally opened._

So, here is the branch with the wacky tests. I have tried a lot of stuff relating to how the dummy classes are declared and used in the tests, but I can't seem to get it working right again and I don't see anything that looks off.

What I have concluded is that the tests are deterministic, the first in each of currency and country_code attributes spec works, the rest fails (it's like it's not calling the constructor at all for any but the first). For the new tests, the attribute validations, I have no idea. I think it's the same issue affecting both and the order the suit is run determines if the attribute validators pass or fail.

I get anywhere from 3 to 5 failed tests locally...