### PR TITLE
Customer validator spec uses shared context

### DIFF
--- a/lib/fortnox/api/validators/customer.rb
+++ b/lib/fortnox/api/validators/customer.rb
@@ -8,12 +8,13 @@ module Fortnox
         using_validations do
 
           VAT_TYPES = ['SEVAT', 'SEREVERSEDVAT', 'EUREVERSEDVAT', 'EUVAT', 'EXPORT']
+          TYPES = ['PRIVATE', 'COMPANY']
 
           validates_presence_of :name
 
-          validates_inclusion_of :sales_account,  within: (0..9999),               if: :sales_account?
-          validates_inclusion_of :type,           within: ['PRIVATE', 'COMPANY'],  if: :type?
-          validates_inclusion_of :vat_type,       within: VAT_TYPES,               if: :vat_type?
+          validates_inclusion_of :sales_account,  within: (0..9999),  if: :sales_account?
+          validates_inclusion_of :type,           within: TYPES,      if: :type?
+          validates_inclusion_of :vat_type,       within: VAT_TYPES,  if: :vat_type?
 
         end
 

--- a/lib/fortnox/api/validators/customer.rb
+++ b/lib/fortnox/api/validators/customer.rb
@@ -11,9 +11,6 @@ module Fortnox
 
           validates_presence_of :name
 
-          validates_length_of :currency,      length: 3,  if: :currency?
-          validates_length_of :country_code,  length: 2,  if: :country_code?
-
           validates_inclusion_of :sales_account,  within: (0..9999),               if: :sales_account?
           validates_inclusion_of :type,           within: ['PRIVATE', 'COMPANY'],  if: :type?
           validates_inclusion_of :vat_type,       within: VAT_TYPES,               if: :vat_type?

--- a/lib/fortnox/api/validators/customer.rb
+++ b/lib/fortnox/api/validators/customer.rb
@@ -1,9 +1,14 @@
 require "fortnox/api/validators/base"
+require "fortnox/api/validators/attributes/country_code"
+require "fortnox/api/validators/attributes/currency"
 
 module Fortnox
   module API
     module Validator
       class Customer < Fortnox::API::Validator::Base
+
+        include Fortnox::API::Validator::Attribute::CountryCode
+        include Fortnox::API::Validator::Attribute::Currency
 
         using_validations do
 

--- a/spec/fortnox/api/validators/context.rb
+++ b/spec/fortnox/api/validators/context.rb
@@ -13,7 +13,7 @@ shared_context 'validator context' do
   end
   shared_examples_for 'invalid' do |attribute, values, error_type|
     values.each do |value|
-      context "when #{attribute} set to #{value}" do
+      context "when :#{attribute} set to #{value}" do
         include_examples 'behaves like invalid', attribute, value, error_type
       end
     end
@@ -21,14 +21,14 @@ shared_context 'validator context' do
 
   shared_examples_for 'valid' do |attribute, values|
     values.each do |value|
-      context "when #{attribute} set to #{value}" do
+      context "when :#{attribute} set to #{value}" do
         include_examples 'behaves like valid', attribute, value
       end
     end
   end
 
   shared_examples_for 'validates length of string' do |attribute, length|
-    context "with #{attribute} set to string with" do
+    context "with :#{attribute} set to string with" do
       context "length 0 (empty string)" do
         include_examples 'behaves like valid', attribute, ''
       end
@@ -47,7 +47,7 @@ shared_context 'validator context' do
   end
 
   shared_examples_for 'validates inclusion of number' do |attribute, min_value, max_value|
-    context "with #{attribute} set to" do
+    context "with :#{attribute} set to" do
       context "minimum value (#{min_value})" do
         include_examples 'behaves like valid', attribute, min_value
       end

--- a/spec/fortnox/api/validators/context.rb
+++ b/spec/fortnox/api/validators/context.rb
@@ -13,7 +13,7 @@ shared_context 'validator context' do
   end
   shared_examples_for 'invalid' do |attribute, values, error_type|
     values.each do |value|
-      context "when :#{attribute} set to #{value}" do
+      context "when #{attribute.inspect} set to #{value}" do
         include_examples 'behaves like invalid', attribute, value, error_type
       end
     end
@@ -21,14 +21,14 @@ shared_context 'validator context' do
 
   shared_examples_for 'valid' do |attribute, values|
     values.each do |value|
-      context "when :#{attribute} set to #{value}" do
+      context "when #{attribute.inspect} set to #{value}" do
         include_examples 'behaves like valid', attribute, value
       end
     end
   end
 
   shared_examples_for 'validates length of string' do |attribute, length|
-    context "with :#{attribute} set to string with" do
+    context "with #{attribute.inspect} set to string with" do
       context "length 0 (empty string)" do
         include_examples 'behaves like valid', attribute, ''
       end
@@ -47,7 +47,7 @@ shared_context 'validator context' do
   end
 
   shared_examples_for 'validates inclusion of number' do |attribute, min_value, max_value|
-    context "with :#{attribute} set to" do
+    context "with #{attribute.inspect} set to" do
       context "minimum value (#{min_value})" do
         include_examples 'behaves like valid', attribute, min_value
       end
@@ -67,7 +67,7 @@ shared_context 'validator context' do
   end
 
   shared_examples_for 'validates inclusion of string' do |attribute, valid_strings, invalid_string|
-    context "with :#{attribute} set to" do
+    context "with #{attribute.inspect} set to" do
       valid_strings.each do |valid_string|
         context "\"#{valid_string}\"" do
           include_examples 'behaves like valid', attribute, valid_string

--- a/spec/fortnox/api/validators/context.rb
+++ b/spec/fortnox/api/validators/context.rb
@@ -46,7 +46,7 @@ shared_context 'validator context' do
     end
   end
 
-  shared_examples_for 'validates inclusion of' do |attribute, min_value, max_value|
+  shared_examples_for 'validates inclusion of number' do |attribute, min_value, max_value|
     context "with #{attribute} set to" do
       context "minimum value (#{min_value})" do
         include_examples 'behaves like valid', attribute, min_value
@@ -63,6 +63,34 @@ shared_context 'validator context' do
       context "too big value (#{max_value + 1})" do
         include_examples 'behaves like invalid', attribute, max_value + 1, :inclusion
       end
+    end
+  end
+
+  shared_examples_for 'validates inclusion of string' do |attribute, valid_strings|
+    context "with #{attribute} set to" do
+      valid_strings.each do |valid_string|
+        context "\"#{valid_string}\"" do
+          include_examples 'behaves like valid', attribute, valid_string
+        end
+      end
+
+      context 'a string not allowed' do
+        # Try first valid string and append nonsense
+        include_examples 'behaves like invalid',
+                         attribute,
+                         valid_strings.first + '123nonsense123',
+                         :inclusion
+      end
+    end
+  end
+
+  shared_examples_for 'required attributes' do |model_class|
+    context 'with required attributes' do
+      it{ is_expected.to be_valid( valid_model ) }
+    end
+
+    context 'without required attributes' do
+      it{ is_expected.to_not be_valid( model_class.new ) }
     end
   end
 end

--- a/spec/fortnox/api/validators/context.rb
+++ b/spec/fortnox/api/validators/context.rb
@@ -66,19 +66,25 @@ shared_context 'validator context' do
     end
   end
 
-  shared_examples_for 'validates inclusion of string' do |attribute, valid_strings|
-    context "with #{attribute} set to" do
+  shared_examples_for 'validates inclusion of string' do |attribute, valid_strings, invalid_string|
+    context "with :#{attribute} set to" do
       valid_strings.each do |valid_string|
         context "\"#{valid_string}\"" do
           include_examples 'behaves like valid', attribute, valid_string
         end
       end
 
-      context 'a nonsense string' do
+      if invalid_string.nil?
+        self::NONSENSE_STRING = valid_strings.first + '123nonsense123'
+      else
+        self::NONSENSE_STRING = invalid_string
+      end
+
+      context "nonsense string '#{self::NONSENSE_STRING}'" do
         # Try first valid string and append nonsense
         include_examples 'behaves like invalid',
                          attribute,
-                         valid_strings.first + '123nonsense123',
+                         self::NONSENSE_STRING,
                          :inclusion
       end
     end

--- a/spec/fortnox/api/validators/context.rb
+++ b/spec/fortnox/api/validators/context.rb
@@ -74,7 +74,7 @@ shared_context 'validator context' do
         end
       end
 
-      context 'a string not allowed' do
+      context 'a nonsense string' do
         # Try first valid string and append nonsense
         include_examples 'behaves like invalid',
                          attribute,

--- a/spec/fortnox/api/validators/customer_spec.rb
+++ b/spec/fortnox/api/validators/customer_spec.rb
@@ -13,21 +13,19 @@ describe Fortnox::API::Validator::Customer do
   end
 
   describe '.validate Customer' do
-    include_examples 'required attributes', Fortnox::API::Model::Customer
+   include_examples 'required attributes', Fortnox::API::Model::Customer
 
-    include_examples 'validates inclusion of number', :sales_account, 0, 9999.0
+   include_examples 'validates inclusion of number', :sales_account, 0, 9999.0
 
-    include_examples 'validates inclusion of string',
-                     :type,
-                     described_class::TYPES
-    include_examples 'validates inclusion of string',
-                     :vat_type,
-                     described_class::VAT_TYPES
-    include_examples 'validates inclusion of string',
-                     :country_code,
-                     described_class::COUNTRY_CODES
-    include_examples 'validates inclusion of string',
-                     :currency,
-                     described_class::CURRENCIES
+   include_examples 'validates inclusion of string', :type, described_class::TYPES
+   include_examples 'validates inclusion of string', :vat_type, described_class::VAT_TYPES
+   include_examples 'validates inclusion of string',
+                    :country_code,
+                    described_class::COUNTRY_CODES,
+                    'aaa'
+   include_examples 'validates inclusion of string',
+                    :currency,
+                    described_class::CURRENCIES,
+                    '-_-'
   end
 end

--- a/spec/fortnox/api/validators/customer_spec.rb
+++ b/spec/fortnox/api/validators/customer_spec.rb
@@ -17,9 +17,11 @@ describe Fortnox::API::Validator::Customer do
 
     include_examples 'validates inclusion of number', :sales_account, 0, 9999.0
 
-    TYPES = ['PRIVATE', 'COMPANY']
-    VAT_TYPES = ['SEVAT', 'SEREVERSEDVAT', 'EUREVERSEDVAT', 'EUVAT', 'EXPORT']
-    include_examples 'validates inclusion of string', :type, TYPES
-    include_examples 'validates inclusion of string', :vat_type, VAT_TYPES
+    include_examples 'validates inclusion of string',
+                     :type,
+                     described_class::TYPES
+    include_examples 'validates inclusion of string',
+                     :vat_type,
+                     described_class::VAT_TYPES
   end
 end

--- a/spec/fortnox/api/validators/customer_spec.rb
+++ b/spec/fortnox/api/validators/customer_spec.rb
@@ -1,33 +1,25 @@
 require 'spec_helper'
-require 'fortnox/api/validators/customer'
 require 'fortnox/api/models/customer'
+require 'fortnox/api/validators/context'
+require 'fortnox/api/validators/customer'
 
 describe Fortnox::API::Validator::Customer do
   subject{ described_class.new }
 
-  describe '.validate' do
-    context 'Customer with valid, simple attributes' do
-      let( :customer ){ Fortnox::API::Model::Customer.new( name: 'Test' ) }
+  let( :model_class ){ Fortnox::API::Model::Customer }
 
-      it 'is valid' do
-        expect( subject.validate( customer )).to eql( true )
-      end
-    end
-
-    context 'Customer with invalid sales_account' do
-      let( :customer ){ Fortnox::API::Model::Customer.new( name: 'Test', sales_account: 99999 ) }
-
-      it 'is invalid' do
-        expect( subject.validate( customer )).to eql( false )
-      end
-
-      it 'includes "sales_account" in violations' do
-        subject.validate( customer )
-
-        expect( subject.violations.any?{ |v| v.rule.attribute_name == :sales_account }).to eql( true )
-        expect( subject.violations.any?{ |v| v.rule.type == :inclusion }).to eql( true )
-      end
-    end
+  include_context 'validator context' do
+    let( :valid_model ){ model_class.new( name: 'A customer' ) }
   end
 
+  describe '.validate Customer' do
+    include_examples 'required attributes', Fortnox::API::Model::Customer
+
+    include_examples 'validates inclusion of number', :sales_account, 0, 9999.0
+
+    TYPES = ['PRIVATE', 'COMPANY']
+    VAT_TYPES = ['SEVAT', 'SEREVERSEDVAT', 'EUREVERSEDVAT', 'EUVAT', 'EXPORT']
+    include_examples 'validates inclusion of string', :type, TYPES
+    include_examples 'validates inclusion of string', :vat_type, VAT_TYPES
+  end
 end

--- a/spec/fortnox/api/validators/customer_spec.rb
+++ b/spec/fortnox/api/validators/customer_spec.rb
@@ -23,5 +23,11 @@ describe Fortnox::API::Validator::Customer do
     include_examples 'validates inclusion of string',
                      :vat_type,
                      described_class::VAT_TYPES
+    include_examples 'validates inclusion of string',
+                     :country_code,
+                     described_class::COUNTRY_CODES
+    include_examples 'validates inclusion of string',
+                     :currency,
+                     described_class::CURRENCIES
   end
 end

--- a/spec/fortnox/api/validators/customer_spec.rb
+++ b/spec/fortnox/api/validators/customer_spec.rb
@@ -6,10 +6,10 @@ require 'fortnox/api/validators/customer'
 describe Fortnox::API::Validator::Customer do
   subject{ described_class.new }
 
-  let( :model_class ){ Fortnox::API::Model::Customer }
-
   include_context 'validator context' do
-    let( :valid_model ){ model_class.new( name: 'A customer' ) }
+    let( :valid_model ) do
+      Fortnox::API::Model::Customer.new( name: 'A customer' )
+    end
   end
 
   describe '.validate Customer' do

--- a/spec/fortnox/api/validators/invoice_spec.rb
+++ b/spec/fortnox/api/validators/invoice_spec.rb
@@ -13,13 +13,7 @@ describe Fortnox::API::Validator::Invoice do
   end
 
   describe '.validate Invoice' do
-    context 'with required attributes' do
-      it{ is_expected.to be_valid( valid_model ) }
-    end
-
-    context 'without required attributes' do
-      it{ is_expected.to_not be_valid( model_class.new ) }
-    end
+    include_examples 'required attributes', Fortnox::API::Model::Invoice
 
     include_examples 'validates length of string', :address1, 1024
     include_examples 'validates length of string', :address2, 1024
@@ -34,9 +28,9 @@ describe Fortnox::API::Validator::Invoice do
     include_examples 'validates length of string', :your_reference, 50
     include_examples 'validates length of string', :zip_code, 1024
 
-    include_examples 'validates inclusion of', :administration_fee, 0, 99_999_999_999.0
-    include_examples 'validates inclusion of', :currency_rate, 0, 999_999_999_999_999.0
-    include_examples 'validates inclusion of', :currency_unit, 0, 999_999_999_999_999.0
-    include_examples 'validates inclusion of', :freight, 0, 99_999_999_999.0
+    include_examples 'validates inclusion of number', :administration_fee, 0, 99_999_999_999.0
+    include_examples 'validates inclusion of number', :currency_rate, 0, 999_999_999_999_999.0
+    include_examples 'validates inclusion of number', :currency_unit, 0, 999_999_999_999_999.0
+    include_examples 'validates inclusion of number', :freight, 0, 99_999_999_999.0
   end
 end

--- a/spec/fortnox/api/validators/row_spec.rb
+++ b/spec/fortnox/api/validators/row_spec.rb
@@ -18,10 +18,10 @@ describe Fortnox::API::Validator::Row do
     include_examples 'validates length of string', :article_number, 50
     include_examples 'validates length of string', :description, 50
 
-    include_examples 'validates inclusion of', :account_number, 0, 9999
-    include_examples 'validates inclusion of', :delivered_quantity, 0, 9_999_999_999_999.0
-    include_examples 'validates inclusion of', :discount, 0, 99_999_999_999.0
-    include_examples 'validates inclusion of', :house_work_hours_to_report, 0, 99_999
-    include_examples 'validates inclusion of', :price, 0, 99_999_999_999.0
+    include_examples 'validates inclusion of number', :account_number, 0, 9999
+    include_examples 'validates inclusion of number', :delivered_quantity, 0, 9_999_999_999_999.0
+    include_examples 'validates inclusion of number', :discount, 0, 99_999_999_999.0
+    include_examples 'validates inclusion of number', :house_work_hours_to_report, 0, 99_999
+    include_examples 'validates inclusion of number', :price, 0, 99_999_999_999.0
   end
 end


### PR DESCRIPTION
Reopening of #12 but now against `development` branch instead of `master`.

Original message:
When introducing shared context to the validators/customer_spec,
I found that validators for currency and country_code was
not working. These are separate attributes and are already validated.
For instance, if assigning 'A' to currency, it is still nil and no
validations are added. We must either change the attribute classes
and add the error there, or skip error messages for these attributes.

Additionally, validators context is updated with a shared examples
for validating inclusion of strings and the former shared examples
'validate inclusion of' is now called 'validate inclusion of number'.