### PR TITLE
Fix 62

### DIFF
--- a/lib/fortnox/api/models/base.rb
+++ b/lib/fortnox/api/models/base.rb
@@ -55,12 +55,27 @@ module Fortnox
           @saved
         end
 
+        # Override to_hash to manage nested models correctly
+        def to_hash *args
+          hash_nested_models(super)
+        end
+
       private
 
         def private_attributes
           @@private_attributes ||= attribute_set.select{ |a| !a.public_writer? }
         end
 
+        # Turns nested models to hash
+        def hash_nested_models(hash)
+          hash.each do |k,v|
+            if v.respond_to?(:to_hash)
+              hash[k] = v.to_hash
+            elsif v.is_a?(Array)
+              hash[k] = v.map(&:to_hash)
+            end
+          end
+        end
       end
     end
   end

--- a/lib/fortnox/api/models/order.rb
+++ b/lib/fortnox/api/models/order.rb
@@ -19,6 +19,13 @@ module Fortnox
 
         # OrderRows Separate object
         attribute :order_rows, Array[OrderRow]
+
+        # Override to_hash to convert nested OrderRows to hash correctly.
+        def to_hash *args
+          main_hash = super
+          main_hash[:order_rows] = self.order_rows.map(&:to_hash)
+          main_hash
+        end
       end
     end
   end

--- a/lib/fortnox/api/models/order.rb
+++ b/lib/fortnox/api/models/order.rb
@@ -19,13 +19,6 @@ module Fortnox
 
         # OrderRows Separate object
         attribute :order_rows, Array[OrderRow]
-
-        # Override to_hash to convert nested OrderRows to hash correctly.
-        def to_hash *args
-          main_hash = super
-          main_hash[:order_rows] = self.order_rows.map(&:to_hash)
-          main_hash
-        end
       end
     end
   end

--- a/lib/fortnox/api/models/order_row.rb
+++ b/lib/fortnox/api/models/order_row.rb
@@ -6,7 +6,7 @@ module Fortnox
       class OrderRow < Fortnox::API::Model::Base
         include DocumentRow
         #OrderedQuantity Ordered quantity
-        attribute :order_quantity, Float
+        attribute :ordered_quantity, Float
       end
     end
   end

--- a/lib/fortnox/api/repositories/base/json_convertion.rb
+++ b/lib/fortnox/api/repositories/base/json_convertion.rb
@@ -39,7 +39,7 @@ module Fortnox
 
         def convert_hash_keys_to_json_format( hash, key_map )
           hash.each_with_object( {} ) do |(key, value), json_hash|
-            if value.is_a?(Array) # Nested model?
+            if value.is_a?(Array) # Is attribute a nested model?
               nested_models = []
               value.each do |nested_model|
                 nested_key_map = key_map.fetch( key, {} )
@@ -53,7 +53,7 @@ module Fortnox
         end
 
         def convert_key_to_json( key, key_map )
-          translation = key_map.fetch( key ){ default_key_to_json_transform( key ) }
+          key_map.fetch( key ){ default_key_to_json_transform( key ) }
         end
 
         def default_key_to_json_transform( key )
@@ -69,7 +69,7 @@ module Fortnox
 
         # Removes nil values and empty collections recursively from Hash
         def clean_hash( hash )
-          cleaned_hash = hash.select{ |k, v| v != nil }
+          cleaned_hash = hash.select{ |_, v| v != nil }
           cleaned_hash.each do |k, v|
             cleaned_hash[k] = clean_collection( v ) if v.respond_to?( :each )
           end
@@ -82,6 +82,8 @@ module Fortnox
           when Hash
             collection = clean_hash( collection )
           end
+
+          collection
         end
 
         # Removes nil values and empty collections recursively from Array

--- a/lib/fortnox/api/repositories/base/json_convertion.rb
+++ b/lib/fortnox/api/repositories/base/json_convertion.rb
@@ -13,7 +13,7 @@ module Fortnox
 
         def entity_to_hash( entity, key_map, json_entity_wrapper, keys_to_filter )
           entity_hash = entity.to_hash
-          clean_entity_hash = sanitise( entity_hash, keys_to_filter )
+          clean_entity_hash = remove_nil_values( sanitise( entity_hash, keys_to_filter ) )
           entity_json_hash = convert_hash_keys_to_json_format( clean_entity_hash, key_map )
           { json_entity_wrapper => entity_json_hash }
         end
@@ -58,14 +58,51 @@ module Fortnox
           end
         end
 
-        # Removes nil values recursively
+        # Removes nil values recursively from Hash
         def remove_nil_values( hash )
           hash.each do |key, value|
-            remove_nil_values(value) if value.is_a?(Hash)
-            hash.delete(key) if value.nil?
+            if value.nil?
+              hash.delete( key )
+            else
+              clean_collection( value )
+            end
+          end
+
+          hash.delete_if{ |_, v| v.empty? if v.respond_to?( :empty? ) }
+        end
+
+        def clean_collection ( collection )
+          case collection
+          when Array
+            collection = clean_array( collection )
+          when Hash
+            collection = clean_hash( collection )
           end
         end
 
+        def clean_array( array )
+          array.each do |element|
+            if element.nil?
+              array.remove( element )
+            else
+              clean_collection( element ) if element.respond_to?( :each )
+            end
+          end
+
+          array.delete_if{ |e| e.empty? if e.respond_to?( :empty? )}
+        end
+
+        def clean_hash( hash )
+          hash.each do |key, value|
+            if value.nil?
+              hash.delete( key )
+            else
+              clean_collection( value ) if value.respond_to?( :each )
+            end
+          end
+
+          hash.delete_if{ |_, v| v.empty? if v.respond_to?( :empty )}
+        end
       end
     end
   end

--- a/lib/fortnox/api/repositories/base/json_convertion.rb
+++ b/lib/fortnox/api/repositories/base/json_convertion.rb
@@ -39,12 +39,21 @@ module Fortnox
 
         def convert_hash_keys_to_json_format( hash, key_map )
           hash.each_with_object( {} ) do |(key, value), json_hash|
-            json_hash[ convert_key_to_json( key, key_map ) ] = value
+            if value.is_a?(Array) # Nested model?
+              nested_models = []
+              value.each do |nested_model|
+                nested_key_map = key_map.fetch( key, {} )
+                nested_models << convert_hash_keys_to_json_format( nested_model,  nested_key_map )
+              end
+              json_hash[ convert_key_to_json( key, {} ) ] = nested_models
+            else # Simple attribute
+              json_hash[ convert_key_to_json( key, key_map ) ] = value
+            end
           end
         end
 
         def convert_key_to_json( key, key_map )
-          key_map.fetch( key ){ default_key_to_json_transform( key ) }
+          translation = key_map.fetch( key ){ default_key_to_json_transform( key ) }
         end
 
         def default_key_to_json_transform( key )

--- a/lib/fortnox/api/repositories/base/json_convertion.rb
+++ b/lib/fortnox/api/repositories/base/json_convertion.rb
@@ -58,8 +58,12 @@ module Fortnox
           end
         end
 
+        # Removes nil values recursively
         def remove_nil_values( hash )
-          hash.delete_if{ |_, value| value.nil? }
+          hash.each do |key, value|
+            remove_nil_values(value) if value.is_a?(Hash)
+            hash.delete(key) if value.nil?
+          end
         end
 
       end

--- a/lib/fortnox/api/repositories/order.rb
+++ b/lib/fortnox/api/repositories/order.rb
@@ -16,7 +16,10 @@ module Fortnox
             edi_information: 'EDIInformation',
             freight_vat: 'FreightVAT',
             total_vat: 'TotalVAT',
-            vat_included: 'VATIncluded'
+            vat_included: 'VATIncluded',
+            order_rows: {
+              vat: 'VAT'
+            }
           },
           keys_filtered_on_save: [
             :url,

--- a/spec/fortnox/api/models/base_spec.rb
+++ b/spec/fortnox/api/models/base_spec.rb
@@ -3,14 +3,20 @@ require 'fortnox/api/models/base'
 
 describe Fortnox::API::Model::Base do
   using_test_classes do
+    class NestedEntity < Fortnox::API::Model::Base
+      attribute :string, String
+    end
+
     class Entity < Fortnox::API::Model::Base
       attribute :private, String, writer: :private
       attribute :string, String
       attribute :number, Integer, default: 42
+      attribute :nested_entity, NestedEntity
+      attribute :nested_entities, Array[NestedEntity]
     end
   end
 
-  describe '.new' do
+  describe '#new' do
     context 'with basic attribute' do
       subject{ Entity.new( string: 'Test' ) }
 
@@ -20,7 +26,7 @@ describe Fortnox::API::Model::Base do
     end
   end
 
-  describe '.update' do
+  describe '#update' do
     let(:original){ Entity.new( string: 'Test' ) }
 
     context 'with new, simple value' do
@@ -73,4 +79,54 @@ describe Fortnox::API::Model::Base do
     end
   end
 
+  describe '#to_hash' do
+    let( :string ){ 'Some string' }
+
+    subject{ model.to_hash }
+
+    shared_examples 'attributes hash' do
+      let( :default_number ){ 42 }
+      it{ is_expected.to include( string: string ) }
+      it{ is_expected.to include( private: nil ) }
+      it{ is_expected.to include( number: default_number ) }
+    end
+
+    context 'without nested models' do
+      let( :model ){ Entity.new( string: string ) }
+
+      include_examples 'attributes hash'
+    end
+
+    context 'with nested models' do
+      let( :nested_entities_0_string ){ 'Nested 0' }
+      let( :nested_entities_1_string ){ 'Nested 1' }
+      let( :nested_string ){ 'Nested String' }
+      let( :model ) do
+        nested_entities_0 = NestedEntity.new( string: nested_entities_0_string )
+        nested_entities_1 = NestedEntity.new( string: nested_entities_1_string )
+        nested_entity = NestedEntity.new( string: nested_string )
+        Entity.new( string: string,
+                    nested_entities: [nested_entities_0, nested_entities_1],
+                    nested_entity: nested_entity )
+      end
+
+      include_examples 'attributes hash'
+
+      it 'turns nested entity into hash' do
+        expect( subject[:nested_entity] ).to eq( { string: nested_string } )
+      end
+
+      describe 'in array' do
+        it 'turns first nested attribute to hash' do
+          hash = { string: nested_entities_0_string }
+          expect( subject[:nested_entities][0] ).to eq( hash )
+        end
+
+        it 'turns second nested attribute to hash' do
+          hash = { string: nested_entities_1_string }
+          expect( subject[:nested_entities][1] ).to eq( hash )
+        end
+      end
+    end
+  end
 end

--- a/spec/fortnox/api/repositories/base/json_convertion_spec.rb
+++ b/spec/fortnox/api/repositories/base/json_convertion_spec.rb
@@ -14,7 +14,7 @@ describe Fortnox::API::Repository::JSONConvertion do
     end
 
     context 'when no nil values present' do
-      let(:hash){ { a: 'a', b: 'b', c: 'c'} }
+      let(:hash){ { a: 'a', b: 'b', c: 'c' } }
 
       it 'returns equal hash' do
         is_expected.to eq( hash )
@@ -65,7 +65,7 @@ describe Fortnox::API::Repository::JSONConvertion do
           is_expected.to eq(
             {
               a: 'a',
-              b: { a: 'a', c: 'c'},
+              b: { a: 'a', c: 'c' },
               c: { b: 'b' }
             }
           )
@@ -75,7 +75,7 @@ describe Fortnox::API::Repository::JSONConvertion do
 
     context 'when nested array' do
       context 'with empty array' do
-        let(:hash) { { a: [], b: 'b', c: [] } }
+        let(:hash){ { a: [], b: 'b', c: [] } }
 
         it 'returns equal hash' do
           is_expected.to eq( hash )
@@ -108,7 +108,7 @@ describe Fortnox::API::Repository::JSONConvertion do
         it 'returns hash without nil values' do
           is_expected.to eq(
             {
-              '1' =>'1a',
+              '1' => '1a',
               '2' => [{ a: '2a' }, {}, '2c'],
               '3' => [{}, { b: '3b' }],
               '4' => [{}, {}]

--- a/spec/fortnox/api/repositories/base/json_convertion_spec.rb
+++ b/spec/fortnox/api/repositories/base/json_convertion_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+require 'fortnox/api/repositories/base/json_convertion'
+
+describe Fortnox::API::Repository::JSONConvertion do
+  describe 'remove_nil_values' do
+    subject{ described_class.remove_nil_values( hash ) }
+
+    context 'when empty hash given' do
+      let(:hash){ {} }
+
+      it 'returns an empty hash' do
+        is_expected.to eq( {} )
+      end
+    end
+
+    context 'when no nil values present' do
+      let(:hash){ { a: 'a', b: 'b', c: 'c'} }
+
+      it 'returns equal hash' do
+        is_expected.to eq( hash )
+      end
+    end
+
+    context 'when nil values present' do
+      let(:hash){ { a: 'a', b: nil, c: 'c' } }
+
+      it 'returns hash without nil values' do
+        is_expected.to eq( a: 'a', c: 'c' )
+      end
+    end
+
+    context 'when nested hash' do
+
+      context 'with empty hash' do
+        let(:hash){ { a: {}, b: 'b', c: {} } }
+
+        it 'returns equal hash' do
+          is_expected.to eq( hash )
+        end
+      end
+
+      context 'without nil values present' do
+        let(:hash) do
+          {
+            a: 'a',
+            b: { a: 'a', b: 'b' },
+            c: { a: 'a' }
+          }
+        end
+
+        it 'returns equal hash' do
+          is_expected.to eq( hash )
+        end
+      end
+      context 'with nil values present' do
+        let(:hash) do
+          {
+            a: 'a',
+            b: { a: 'a', b: nil, c: 'c' },
+            c: { a: nil, b: 'b' }
+          }
+        end
+
+        it 'returns hash without nil values' do
+          is_expected.to eq(
+            {
+              a: 'a',
+              b: { a: 'a', c: 'c'},
+              c: { b: 'b' }
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/fortnox/api/repositories/base/json_convertion_spec.rb
+++ b/spec/fortnox/api/repositories/base/json_convertion_spec.rb
@@ -30,7 +30,6 @@ describe Fortnox::API::Repository::JSONConvertion do
     end
 
     context 'when nested hash' do
-
       context 'with empty hash' do
         let(:hash){ { a: {}, b: 'b', c: {} } }
 
@@ -52,6 +51,7 @@ describe Fortnox::API::Repository::JSONConvertion do
           is_expected.to eq( hash )
         end
       end
+
       context 'with nil values present' do
         let(:hash) do
           {
@@ -67,6 +67,50 @@ describe Fortnox::API::Repository::JSONConvertion do
               a: 'a',
               b: { a: 'a', c: 'c'},
               c: { b: 'b' }
+            }
+          )
+        end
+      end
+    end
+
+    context 'when nested array' do
+      context 'with empty array' do
+        let(:hash) { { a: [], b: 'b', c: [] } }
+
+        it 'returns equal hash' do
+          is_expected.to eq( hash )
+        end
+      end
+
+      context 'without nil values present' do
+        let(:hash) do
+          {
+            a: 'a',
+            b: [{ a: 'a' }, { b: 'b' }],
+            c: [{ a: 'a' }]
+          }
+        end
+
+        it 'returns equal hash' do
+          is_expected.to eq( hash )
+        end
+      end
+      context 'with nil values present', focus: true do
+        let(:hash) do
+          {
+            '1' => '1a',
+            '2' => [{ a: '2a' }, { b: nil }, '2c'],
+            '3' => [{ a: nil }, { b: '3b' }],
+            '4' => [{ a: nil }, { b: nil }]
+          }
+        end
+
+        it 'returns hash without nil values' do
+          is_expected.to eq(
+            {
+              '1' =>'1a',
+              '2' => [{ a: '2a' }, '2c'],
+              '3' => [{ b: '3b' }]
             }
           )
         end

--- a/spec/fortnox/api/repositories/base/json_convertion_spec.rb
+++ b/spec/fortnox/api/repositories/base/json_convertion_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 require 'fortnox/api/repositories/base/json_convertion'
 
 describe Fortnox::API::Repository::JSONConvertion do
-  describe 'remove_nil_values' do
-    subject{ described_class.remove_nil_values( hash ) }
+  describe 'clean_hash' do
+    subject{ described_class.clean_hash( hash ) }
 
     context 'when empty hash given' do
       let(:hash){ {} }
@@ -95,7 +95,7 @@ describe Fortnox::API::Repository::JSONConvertion do
           is_expected.to eq( hash )
         end
       end
-      context 'with nil values present', focus: true do
+      context 'with nil values present' do
         let(:hash) do
           {
             '1' => '1a',
@@ -109,8 +109,9 @@ describe Fortnox::API::Repository::JSONConvertion do
           is_expected.to eq(
             {
               '1' =>'1a',
-              '2' => [{ a: '2a' }, '2c'],
-              '3' => [{ b: '3b' }]
+              '2' => [{ a: '2a' }, {}, '2c'],
+              '3' => [{}, { b: '3b' }],
+              '4' => [{}, {}]
             }
           )
         end

--- a/spec/fortnox/api/repositories/base/json_convertion_spec.rb
+++ b/spec/fortnox/api/repositories/base/json_convertion_spec.rb
@@ -118,4 +118,64 @@ describe Fortnox::API::Repository::JSONConvertion do
       end
     end
   end
+
+  describe 'convert_hash_keys_to_json_format' do
+    let(:admin_fee) { '22' }
+    let(:comments) { 'A comments' }
+    let(:customer_number) { '1' }
+    let(:edi_info) { 'Some EDI info' }
+    let(:ocr) { '9834782497884123'}
+    let(:order_row_1_price) { '10' }
+    let(:order_row_2_price) { '30' }
+    let(:order_row_1_vat) { '2.5' }
+    let(:order_row_2_vat) { '150' }
+    let(:hash) do
+      {
+        administration_fee_vat: admin_fee,
+        comments: comments,
+        customer_number: customer_number,
+        edi_information: edi_info,
+        invoice_rows: [
+          { price: order_row_1_price, vat: order_row_1_vat },
+          { price: order_row_2_price, vat: order_row_2_vat }
+        ],
+        ocr: ocr
+      }
+    end
+
+    let(:admin_fee_json_key) { "AdministrationFeeVAT" }
+    let(:edi_info_json_key) { "EDIInformation" }
+    let(:ocr_json_key) { "OCR" }
+    let(:vat_json_key) { 'VAT' }
+    let(:key_map) do
+      {
+        administration_fee_vat: admin_fee_json_key,
+        edi_information: edi_info_json_key,
+        ocr: ocr_json_key,
+        order_rows: { vat: vat_json_key }
+        # TODO: edi_information: { "EDIGlobalLocationNumber" }
+      }
+    end
+
+    let(:entity_json_hash) do
+      described_class.convert_hash_keys_to_json_format( hash, key_map )
+    end
+
+    subject{ entity_json_hash }
+
+    it{ is_expected.to include( admin_fee_json_key => admin_fee ) }
+    it{ is_expected.to include( "Comments" => comments ) }
+    it{ is_expected.to include( "CustomerNumber" => customer_number ) }
+    it{ is_expected.to include( edi_info_json_key => edi_info ) }
+    it{ is_expected.to include( ocr_json_key => ocr ) }
+
+    describe 'nested models' do
+      subject{ entity_json_hash["InvoiceRows"] }
+      it do
+        row_1 = { 'Price' => order_row_1_price, vat_json_key => order_row_1_vat }
+        row_2 = { 'Price' => order_row_2_price, vat_json_key => order_row_2_vat }
+        is_expected.to include( [ row_1, row_2 ] )
+      end
+    end
+  end
 end

--- a/spec/fortnox/api/repositories/order_spec.rb
+++ b/spec/fortnox/api/repositories/order_spec.rb
@@ -22,22 +22,59 @@ describe Fortnox::API::Repository::Order, order: :defined, integration: true do
 
   include_examples '.only', :cancelled, 2
 
-  describe 'OrderRow' do
-    let(:model) do
-      Fortnox::API::Model::Order.new(
+  context 'when saving an Order with OrderRows' do
+    shared_examples 'OrderRow attributes' do |order_row, attribute_map|
+      describe 'response' do
+        let( :order_row_response ) do
+          entity_wrapper = described_class.new.options.json_entity_wrapper
+          response[entity_wrapper]['OrderRows'][order_row]
+        end
+
+        attribute_map.each do |attribute, value|
+          it "includes #{attribute.inspect}" do
+            expect( order_row_response[attribute] ).to eq( value )
+          end
+        end
+      end
+    end
+    let(:response) do
+      model = Fortnox::API::Model::Order.new(
         {
           customer_number: '1',
           comments: 'A great comment about something',
           order_rows: [
-            { price: 100.0, vat: '6', article_number: '1' },
-            { price: 101.5, vat: '0', article_number: '1' }]
-        })
-    end
+            { price: 100.0,
+              vat: 6,
+              article_number: '1',
+              ordered_quantity: 1 },
+            { price: 101.5,
+              vat: 0,
+              article_number: '1',
+              ordered_quantity: 2 }]
+        }
+      )
 
-    it 'should save an Order with OrderRows' do
-      VCR.use_cassette('orders/save_new_with_order_rows') do
-        described_class.new.save(model)
+      VCR.use_cassette( 'orders/save_new_with_order_rows' ) do
+        described_class.new.save( model )
       end
     end
+
+    include_examples 'OrderRow attributes',
+                     0,
+                     {
+                       'Price' => 100.0,
+                       'VAT' => 6,
+                       'ArticleNumber' => '1',
+                       'OrderedQuantity' => 1
+                     }
+
+    include_examples 'OrderRow attributes',
+                     1,
+                     {
+                       'Price' => 101.5,
+                       'VAT' => 0,
+                       'ArticleNumber' => '1',
+                       'OrderedQuantity' => 2
+                     }
   end
 end

--- a/spec/fortnox/api/repositories/order_spec.rb
+++ b/spec/fortnox/api/repositories/order_spec.rb
@@ -6,7 +6,6 @@ require 'fortnox/api/repositories/examples/find'
 require 'fortnox/api/repositories/examples/only'
 require 'fortnox/api/repositories/examples/save'
 require 'fortnox/api/repositories/examples/search'
-require 'fortnox/api'
 
 describe Fortnox::API::Repository::Order, order: :defined, integration: true do
   include_context 'environment'

--- a/spec/fortnox/api/repositories/order_spec.rb
+++ b/spec/fortnox/api/repositories/order_spec.rb
@@ -6,6 +6,7 @@ require 'fortnox/api/repositories/examples/find'
 require 'fortnox/api/repositories/examples/only'
 require 'fortnox/api/repositories/examples/save'
 require 'fortnox/api/repositories/examples/search'
+require 'fortnox/api'
 
 describe Fortnox::API::Repository::Order, order: :defined, integration: true do
   include_context 'environment'
@@ -21,4 +22,21 @@ describe Fortnox::API::Repository::Order, order: :defined, integration: true do
   include_examples '.search', :customername, 'A customer'
 
   include_examples '.only', :cancelled, 2
+
+  describe 'OrderRow', focus: true do
+    let(:model) do
+      Fortnox::API::Model::Order.new(
+        {
+          customer_number: '1',
+          comments: 'A great comment about something',
+          order_rows: [{price: 100.0}, {price: 101.5}]
+        })
+    end
+
+    it 'should save an Order with OrderRows' do
+      VCR.use_cassette('orders/save_new_with_order_rows') do
+        described_class.new.save(model)
+      end
+    end
+  end
 end

--- a/spec/fortnox/api/repositories/order_spec.rb
+++ b/spec/fortnox/api/repositories/order_spec.rb
@@ -22,13 +22,15 @@ describe Fortnox::API::Repository::Order, order: :defined, integration: true do
 
   include_examples '.only', :cancelled, 2
 
-  describe 'OrderRow', focus: true do
+  describe 'OrderRow' do
     let(:model) do
       Fortnox::API::Model::Order.new(
         {
           customer_number: '1',
           comments: 'A great comment about something',
-          order_rows: [{price: 100.0}, {price: 101.5}]
+          order_rows: [
+            { price: 100.0, vat: '6', article_number: '1' },
+            { price: 101.5, vat: '0', article_number: '1' }]
         })
     end
 

--- a/spec/fortnox/api/repositories/order_spec.rb
+++ b/spec/fortnox/api/repositories/order_spec.rb
@@ -50,7 +50,7 @@ describe Fortnox::API::Repository::Order, order: :defined, integration: true do
             { price: 101.5,
               vat: 0,
               article_number: '1',
-              ordered_quantity: 2 }]
+              ordered_quantity: 2.5 }]
         }
       )
 
@@ -65,7 +65,7 @@ describe Fortnox::API::Repository::Order, order: :defined, integration: true do
                        'Price' => 100.0,
                        'VAT' => 6,
                        'ArticleNumber' => '1',
-                       'OrderedQuantity' => 1
+                       'OrderedQuantity' => '1.00'
                      }
 
     include_examples 'OrderRow attributes',
@@ -74,7 +74,7 @@ describe Fortnox::API::Repository::Order, order: :defined, integration: true do
                        'Price' => 101.5,
                        'VAT' => 0,
                        'ArticleNumber' => '1',
-                       'OrderedQuantity' => 2
+                       'OrderedQuantity' => '2.50'
                      }
   end
 end

--- a/spec/vcr_cassettes/orders/save_new_with_order_rows.yml
+++ b/spec/vcr_cassettes/orders/save_new_with_order_rows.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 26 Apr 2016 16:05:48 GMT
+      - Wed, 27 Apr 2016 07:38:48 GMT
       Content-Type:
       - application/json
       Connection:
@@ -31,17 +31,17 @@ http_interactions:
       Location:
       - orders
       X-Rack-Responsetime:
-      - '300'
+      - '1982'
       X-Uid:
-      - fb20b585
+      - ba8d8ae8
       X-Build:
       - 42c598a932
     body:
       encoding: UTF-8
-      string: '{"Order":{"@url":"https:\/\/api.fortnox.se\/3\/orders\/18","@urlTaxReductionList":"https:\/\/api.fortnox.se\/3\/taxreductions?filter=orders&referencenumber=18","AdministrationFee":0,"AdministrationFeeVAT":0,"Address1":"","Address2":"","BasisTaxReduction":0,"Cancelled":false,"City":"","Comments":"A
+      string: '{"Order":{"@url":"https:\/\/api.fortnox.se\/3\/orders\/22","@urlTaxReductionList":"https:\/\/api.fortnox.se\/3\/taxreductions?filter=orders&referencenumber=22","AdministrationFee":0,"AdministrationFeeVAT":0,"Address1":"","Address2":"","BasisTaxReduction":0,"Cancelled":false,"City":"","Comments":"A
         great comment about something","ContributionPercent":0,"ContributionValue":0,"CopyRemarks":false,"Country":"","CostCenter":"","Currency":"SEK","CurrencyRate":1,"CurrencyUnit":1,"CustomerName":"Old
-        name","CustomerNumber":"1","DeliveryAddress1":"","DeliveryAddress2":"","DeliveryCity":"","DeliveryCountry":"","DeliveryDate":null,"DeliveryName":"","DeliveryZipCode":"","DocumentNumber":"18","EmailInformation":{"EmailAddressFrom":null,"EmailAddressTo":"","EmailAddressCC":null,"EmailAddressBCC":null,"EmailSubject":"Order
-        {no} bifogas","EmailBody":" "},"ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","Freight":0,"FreightVAT":0,"Gross":0,"HouseWork":false,"InvoiceReference":0,"Labels":[],"Language":"SV","Net":0,"NotCompleted":false,"OfferReference":0,"OrderDate":"2016-04-26","OrderRows":[{"AccountNumber":1030,"ArticleNumber":"1","ContributionPercent":0,"ContributionValue":0,"CostCenter":"","DeliveredQuantity":"0.00","Description":"Testartikel","Discount":0,"DiscountType":"PERCENT","HouseWork":false,"HouseWorkHoursToReport":null,"HouseWorkType":null,"OrderedQuantity":"0.00","Price":100,"Project":"","Total":0,"Unit":"","VAT":6},{"AccountNumber":1030,"ArticleNumber":"1","ContributionPercent":0,"ContributionValue":0,"CostCenter":"","DeliveredQuantity":"0.00","Description":"Testartikel","Discount":0,"DiscountType":"PERCENT","HouseWork":false,"HouseWorkHoursToReport":null,"HouseWorkType":null,"OrderedQuantity":"0.00","Price":101.5,"Project":"","Total":0,"Unit":"","VAT":0}],"OrganisationNumber":"","OurReference":"","Phone1":"","Phone2":"","PriceList":"A","PrintTemplate":"oc","Project":"","Remarks":"","RoundOff":0,"Sent":false,"TaxReduction":null,"TermsOfDelivery":"","TermsOfPayment":0,"Total":0,"TotalToPay":0,"TotalVAT":0,"VATIncluded":false,"WayOfDelivery":"","YourReference":"","YourOrderNumber":"","ZipCode":""}}'
+        name","CustomerNumber":"1","DeliveryAddress1":"","DeliveryAddress2":"","DeliveryCity":"","DeliveryCountry":"","DeliveryDate":null,"DeliveryName":"","DeliveryZipCode":"","DocumentNumber":"22","EmailInformation":{"EmailAddressFrom":null,"EmailAddressTo":"","EmailAddressCC":null,"EmailAddressBCC":null,"EmailSubject":"Order
+        {no} bifogas","EmailBody":" "},"ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","Freight":0,"FreightVAT":0,"Gross":0,"HouseWork":false,"InvoiceReference":0,"Labels":[],"Language":"SV","Net":0,"NotCompleted":false,"OfferReference":0,"OrderDate":"2016-04-27","OrderRows":[{"AccountNumber":1030,"ArticleNumber":"1","ContributionPercent":0,"ContributionValue":0,"CostCenter":"","DeliveredQuantity":"0.00","Description":"Testartikel","Discount":0,"DiscountType":"PERCENT","HouseWork":false,"HouseWorkHoursToReport":null,"HouseWorkType":null,"OrderedQuantity":"0.00","Price":100,"Project":"","Total":0,"Unit":"","VAT":6},{"AccountNumber":1030,"ArticleNumber":"1","ContributionPercent":0,"ContributionValue":0,"CostCenter":"","DeliveredQuantity":"0.00","Description":"Testartikel","Discount":0,"DiscountType":"PERCENT","HouseWork":false,"HouseWorkHoursToReport":null,"HouseWorkType":null,"OrderedQuantity":"0.00","Price":101.5,"Project":"","Total":0,"Unit":"","VAT":0}],"OrganisationNumber":"","OurReference":"","Phone1":"","Phone2":"","PriceList":"A","PrintTemplate":"oc","Project":"","Remarks":"","RoundOff":0,"Sent":false,"TaxReduction":null,"TermsOfDelivery":"","TermsOfPayment":0,"Total":0,"TotalToPay":0,"TotalVAT":0,"VATIncluded":false,"WayOfDelivery":"","YourReference":"","YourOrderNumber":"","ZipCode":""}}'
     http_version: 
-  recorded_at: Tue, 26 Apr 2016 16:05:48 GMT
+  recorded_at: Wed, 27 Apr 2016 07:38:48 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/orders/save_new_with_order_rows.yml
+++ b/spec/vcr_cassettes/orders/save_new_with_order_rows.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.fortnox.se/3/orders/
     body:
       encoding: UTF-8
-      string: '{"Order":{"Comments":"A great comment about something","CustomerNumber":"1","OrderRows":[{"account_number":null,"article_number":null,"contribution_percent":null,"contribution_value":null,"cost_center":null,"delivered_quantity":null,"description":null,"discount":null,"discount_type":null,"house_work":null,"house_work_hours_to_report":null,"house_work_type":null,"price":100.0,"project":null,"total":null,"unit":null,"vat":null,"order_quantity":null},{"account_number":null,"article_number":null,"contribution_percent":null,"contribution_value":null,"cost_center":null,"delivered_quantity":null,"description":null,"discount":null,"discount_type":null,"house_work":null,"house_work_hours_to_report":null,"house_work_type":null,"price":101.5,"project":null,"total":null,"unit":null,"vat":null,"order_quantity":null}]}}'
+      string: '{"Order":{"Comments":"A great comment about something","CustomerNumber":"1","OrderRows":[{"price":100.0},{"price":101.5}]}}'
     headers:
       Content-Type:
       - application/json
@@ -23,20 +23,20 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 22 Apr 2016 14:04:19 GMT
+      - Tue, 26 Apr 2016 09:03:59 GMT
       Content-Type:
       - application/json
       Connection:
       - close
       X-Rack-Responsetime:
-      - '301'
+      - '378'
       X-Uid:
-      - 2c8ff646
+      - 66cbb84a
       X-Build:
       - 42c598a932
     body:
       encoding: UTF-8
-      string: '{"ErrorInformation":{"error":1,"message":"Felaktigt f\u00e4ltnamn (account_number)","code":2001399}}'
+      string: '{"ErrorInformation":{"error":1,"message":"Felaktigt f\u00e4ltnamn (price)","code":2001399}}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 14:04:19 GMT
+  recorded_at: Tue, 26 Apr 2016 09:03:59 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/orders/save_new_with_order_rows.yml
+++ b/spec/vcr_cassettes/orders/save_new_with_order_rows.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.fortnox.se/3/orders/
+    body:
+      encoding: UTF-8
+      string: '{"Order":{"Comments":"A great comment about something","CustomerNumber":"1","OrderRows":["#<Fortnox::API::Model::OrderRow:0x007f564589cbd0>","#<Fortnox::API::Model::OrderRow:0x007f5645880ea8>"]}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 22 Apr 2016 11:09:44 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      X-Rack-Responsetime:
+      - '93'
+      X-Uid:
+      - 64a77c05
+      X-Build:
+      - 42c598a932
+    body:
+      encoding: UTF-8
+      string: '{"ErrorInformation":{"error":1,"message":"Felaktig datastruktur.","code":2002649}}'
+    http_version: 
+  recorded_at: Fri, 22 Apr 2016 11:09:44 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/orders/save_new_with_order_rows.yml
+++ b/spec/vcr_cassettes/orders/save_new_with_order_rows.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.fortnox.se/3/orders/
     body:
       encoding: UTF-8
-      string: '{"Order":{"Comments":"A great comment about something","CustomerNumber":"1","OrderRows":[{"price":100.0},{"price":101.5}]}}'
+      string: '{"Order":{"Comments":"A great comment about something","CustomerNumber":"1","OrderRows":[{"ArticleNumber":"1","Price":100.0,"VAT":6},{"ArticleNumber":"1","Price":101.5,"VAT":0}]}}'
     headers:
       Content-Type:
       - application/json
@@ -17,26 +17,31 @@ http_interactions:
       - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
   response:
     status:
-      code: 400
-      message: Bad Request
+      code: 201
+      message: Created
     headers:
       Server:
       - nginx
       Date:
-      - Tue, 26 Apr 2016 09:03:59 GMT
+      - Tue, 26 Apr 2016 16:05:48 GMT
       Content-Type:
       - application/json
       Connection:
       - close
+      Location:
+      - orders
       X-Rack-Responsetime:
-      - '378'
+      - '300'
       X-Uid:
-      - 66cbb84a
+      - fb20b585
       X-Build:
       - 42c598a932
     body:
       encoding: UTF-8
-      string: '{"ErrorInformation":{"error":1,"message":"Felaktigt f\u00e4ltnamn (price)","code":2001399}}'
+      string: '{"Order":{"@url":"https:\/\/api.fortnox.se\/3\/orders\/18","@urlTaxReductionList":"https:\/\/api.fortnox.se\/3\/taxreductions?filter=orders&referencenumber=18","AdministrationFee":0,"AdministrationFeeVAT":0,"Address1":"","Address2":"","BasisTaxReduction":0,"Cancelled":false,"City":"","Comments":"A
+        great comment about something","ContributionPercent":0,"ContributionValue":0,"CopyRemarks":false,"Country":"","CostCenter":"","Currency":"SEK","CurrencyRate":1,"CurrencyUnit":1,"CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryAddress1":"","DeliveryAddress2":"","DeliveryCity":"","DeliveryCountry":"","DeliveryDate":null,"DeliveryName":"","DeliveryZipCode":"","DocumentNumber":"18","EmailInformation":{"EmailAddressFrom":null,"EmailAddressTo":"","EmailAddressCC":null,"EmailAddressBCC":null,"EmailSubject":"Order
+        {no} bifogas","EmailBody":" "},"ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","Freight":0,"FreightVAT":0,"Gross":0,"HouseWork":false,"InvoiceReference":0,"Labels":[],"Language":"SV","Net":0,"NotCompleted":false,"OfferReference":0,"OrderDate":"2016-04-26","OrderRows":[{"AccountNumber":1030,"ArticleNumber":"1","ContributionPercent":0,"ContributionValue":0,"CostCenter":"","DeliveredQuantity":"0.00","Description":"Testartikel","Discount":0,"DiscountType":"PERCENT","HouseWork":false,"HouseWorkHoursToReport":null,"HouseWorkType":null,"OrderedQuantity":"0.00","Price":100,"Project":"","Total":0,"Unit":"","VAT":6},{"AccountNumber":1030,"ArticleNumber":"1","ContributionPercent":0,"ContributionValue":0,"CostCenter":"","DeliveredQuantity":"0.00","Description":"Testartikel","Discount":0,"DiscountType":"PERCENT","HouseWork":false,"HouseWorkHoursToReport":null,"HouseWorkType":null,"OrderedQuantity":"0.00","Price":101.5,"Project":"","Total":0,"Unit":"","VAT":0}],"OrganisationNumber":"","OurReference":"","Phone1":"","Phone2":"","PriceList":"A","PrintTemplate":"oc","Project":"","Remarks":"","RoundOff":0,"Sent":false,"TaxReduction":null,"TermsOfDelivery":"","TermsOfPayment":0,"Total":0,"TotalToPay":0,"TotalVAT":0,"VATIncluded":false,"WayOfDelivery":"","YourReference":"","YourOrderNumber":"","ZipCode":""}}'
     http_version: 
-  recorded_at: Tue, 26 Apr 2016 09:03:59 GMT
+  recorded_at: Tue, 26 Apr 2016 16:05:48 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/orders/save_new_with_order_rows.yml
+++ b/spec/vcr_cassettes/orders/save_new_with_order_rows.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.fortnox.se/3/orders/
     body:
       encoding: UTF-8
-      string: '{"Order":{"Comments":"A great comment about something","CustomerNumber":"1","OrderRows":["#<Fortnox::API::Model::OrderRow:0x007f564589cbd0>","#<Fortnox::API::Model::OrderRow:0x007f5645880ea8>"]}}'
+      string: '{"Order":{"Comments":"A great comment about something","CustomerNumber":"1","OrderRows":[{"account_number":null,"article_number":null,"contribution_percent":null,"contribution_value":null,"cost_center":null,"delivered_quantity":null,"description":null,"discount":null,"discount_type":null,"house_work":null,"house_work_hours_to_report":null,"house_work_type":null,"price":100.0,"project":null,"total":null,"unit":null,"vat":null,"order_quantity":null},{"account_number":null,"article_number":null,"contribution_percent":null,"contribution_value":null,"cost_center":null,"delivered_quantity":null,"description":null,"discount":null,"discount_type":null,"house_work":null,"house_work_hours_to_report":null,"house_work_type":null,"price":101.5,"project":null,"total":null,"unit":null,"vat":null,"order_quantity":null}]}}'
     headers:
       Content-Type:
       - application/json
@@ -23,20 +23,20 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 22 Apr 2016 11:09:44 GMT
+      - Fri, 22 Apr 2016 14:04:19 GMT
       Content-Type:
       - application/json
       Connection:
       - close
       X-Rack-Responsetime:
-      - '93'
+      - '301'
       X-Uid:
-      - 64a77c05
+      - 2c8ff646
       X-Build:
       - 42c598a932
     body:
       encoding: UTF-8
-      string: '{"ErrorInformation":{"error":1,"message":"Felaktig datastruktur.","code":2002649}}'
+      string: '{"ErrorInformation":{"error":1,"message":"Felaktigt f\u00e4ltnamn (account_number)","code":2001399}}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 11:09:44 GMT
+  recorded_at: Fri, 22 Apr 2016 14:04:19 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/orders/save_new_with_order_rows.yml
+++ b/spec/vcr_cassettes/orders/save_new_with_order_rows.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.fortnox.se/3/orders/
     body:
       encoding: UTF-8
-      string: '{"Order":{"Comments":"A great comment about something","CustomerNumber":"1","OrderRows":[{"ArticleNumber":"1","Price":100.0,"VAT":6},{"ArticleNumber":"1","Price":101.5,"VAT":0}]}}'
+      string: '{"Order":{"Comments":"A great comment about something","CustomerNumber":"1","OrderRows":[{"ArticleNumber":"1","Price":100.0,"VAT":6,"OrderedQuantity":1.0},{"ArticleNumber":"1","Price":101.5,"VAT":0,"OrderedQuantity":2.5}]}}'
     headers:
       Content-Type:
       - application/json
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 27 Apr 2016 07:38:48 GMT
+      - Wed, 27 Apr 2016 07:49:57 GMT
       Content-Type:
       - application/json
       Connection:
@@ -31,17 +31,17 @@ http_interactions:
       Location:
       - orders
       X-Rack-Responsetime:
-      - '1982'
+      - '131'
       X-Uid:
-      - ba8d8ae8
+      - 4da86a23
       X-Build:
       - 42c598a932
     body:
       encoding: UTF-8
-      string: '{"Order":{"@url":"https:\/\/api.fortnox.se\/3\/orders\/22","@urlTaxReductionList":"https:\/\/api.fortnox.se\/3\/taxreductions?filter=orders&referencenumber=22","AdministrationFee":0,"AdministrationFeeVAT":0,"Address1":"","Address2":"","BasisTaxReduction":0,"Cancelled":false,"City":"","Comments":"A
+      string: '{"Order":{"@url":"https:\/\/api.fortnox.se\/3\/orders\/24","@urlTaxReductionList":"https:\/\/api.fortnox.se\/3\/taxreductions?filter=orders&referencenumber=24","AdministrationFee":0,"AdministrationFeeVAT":0,"Address1":"","Address2":"","BasisTaxReduction":0,"Cancelled":false,"City":"","Comments":"A
         great comment about something","ContributionPercent":0,"ContributionValue":0,"CopyRemarks":false,"Country":"","CostCenter":"","Currency":"SEK","CurrencyRate":1,"CurrencyUnit":1,"CustomerName":"Old
-        name","CustomerNumber":"1","DeliveryAddress1":"","DeliveryAddress2":"","DeliveryCity":"","DeliveryCountry":"","DeliveryDate":null,"DeliveryName":"","DeliveryZipCode":"","DocumentNumber":"22","EmailInformation":{"EmailAddressFrom":null,"EmailAddressTo":"","EmailAddressCC":null,"EmailAddressBCC":null,"EmailSubject":"Order
-        {no} bifogas","EmailBody":" "},"ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","Freight":0,"FreightVAT":0,"Gross":0,"HouseWork":false,"InvoiceReference":0,"Labels":[],"Language":"SV","Net":0,"NotCompleted":false,"OfferReference":0,"OrderDate":"2016-04-27","OrderRows":[{"AccountNumber":1030,"ArticleNumber":"1","ContributionPercent":0,"ContributionValue":0,"CostCenter":"","DeliveredQuantity":"0.00","Description":"Testartikel","Discount":0,"DiscountType":"PERCENT","HouseWork":false,"HouseWorkHoursToReport":null,"HouseWorkType":null,"OrderedQuantity":"0.00","Price":100,"Project":"","Total":0,"Unit":"","VAT":6},{"AccountNumber":1030,"ArticleNumber":"1","ContributionPercent":0,"ContributionValue":0,"CostCenter":"","DeliveredQuantity":"0.00","Description":"Testartikel","Discount":0,"DiscountType":"PERCENT","HouseWork":false,"HouseWorkHoursToReport":null,"HouseWorkType":null,"OrderedQuantity":"0.00","Price":101.5,"Project":"","Total":0,"Unit":"","VAT":0}],"OrganisationNumber":"","OurReference":"","Phone1":"","Phone2":"","PriceList":"A","PrintTemplate":"oc","Project":"","Remarks":"","RoundOff":0,"Sent":false,"TaxReduction":null,"TermsOfDelivery":"","TermsOfPayment":0,"Total":0,"TotalToPay":0,"TotalVAT":0,"VATIncluded":false,"WayOfDelivery":"","YourReference":"","YourOrderNumber":"","ZipCode":""}}'
+        name","CustomerNumber":"1","DeliveryAddress1":"","DeliveryAddress2":"","DeliveryCity":"","DeliveryCountry":"","DeliveryDate":null,"DeliveryName":"","DeliveryZipCode":"","DocumentNumber":"24","EmailInformation":{"EmailAddressFrom":null,"EmailAddressTo":"","EmailAddressCC":null,"EmailAddressBCC":null,"EmailSubject":"Order
+        {no} bifogas","EmailBody":" "},"ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","Freight":0,"FreightVAT":0,"Gross":0,"HouseWork":false,"InvoiceReference":0,"Labels":[],"Language":"SV","Net":0,"NotCompleted":false,"OfferReference":0,"OrderDate":"2016-04-27","OrderRows":[{"AccountNumber":1030,"ArticleNumber":"1","ContributionPercent":0,"ContributionValue":0,"CostCenter":"","DeliveredQuantity":"0.00","Description":"Testartikel","Discount":0,"DiscountType":"PERCENT","HouseWork":false,"HouseWorkHoursToReport":null,"HouseWorkType":null,"OrderedQuantity":"1.00","Price":100,"Project":"","Total":0,"Unit":"","VAT":6},{"AccountNumber":1030,"ArticleNumber":"1","ContributionPercent":0,"ContributionValue":0,"CostCenter":"","DeliveredQuantity":"0.00","Description":"Testartikel","Discount":0,"DiscountType":"PERCENT","HouseWork":false,"HouseWorkHoursToReport":null,"HouseWorkType":null,"OrderedQuantity":"2.50","Price":101.5,"Project":"","Total":0,"Unit":"","VAT":0}],"OrganisationNumber":"","OurReference":"","Phone1":"","Phone2":"","PriceList":"A","PrintTemplate":"oc","Project":"","Remarks":"","RoundOff":0,"Sent":false,"TaxReduction":null,"TermsOfDelivery":"","TermsOfPayment":0,"Total":0,"TotalToPay":0,"TotalVAT":0,"VATIncluded":false,"WayOfDelivery":"","YourReference":"","YourOrderNumber":"","ZipCode":""}}'
     http_version: 
-  recorded_at: Wed, 27 Apr 2016 07:38:48 GMT
+  recorded_at: Wed, 27 Apr 2016 07:49:57 GMT
 recorded_with: VCR 3.0.1


### PR DESCRIPTION
Fixes #62. It introduces nested translation hashes for nested attributes. It only includes an implementation for `Order` and its nested `OrderRows`.

The solution is not perfect. Right now, the nested model is defined as a nested hash in the repository, for instance:

```
 attribute_name_to_json_key_map: {
  administration_fee_vat: 'AdministrationFeeVAT',
  edi_information: 'EDIInformation',
  freight_vat: 'FreightVAT',
  total_vat: 'TotalVAT',
  vat_included: 'VATIncluded',
  order_rows: {
    vat: 'VAT'
  }
},
```

Here, `order_rows` is a nested hash. But what if the attribute `order_rows` itself needs a translation? Additionally, what if the nested model's translation does not need any specific JSON translations? Would you then implement it as just an empty hash? Somehow `JSONConvertion` must know that an attribute is a nested model. Otherwise, it will not recursively translate that nested model's attributes.

A better solution may be to add a new hash to the Repository named `nested_models` where you declare what nested models there are. Then you only add them to `attribute_name_to_json_key_map` if they have some attribute that needs a specific translation.