### PR TITLE
Tests for Repository::Order added

### DIFF
--- a/spec/fortnox/api/repositories/examples/only.rb
+++ b/spec/fortnox/api/repositories/examples/only.rb
@@ -1,4 +1,4 @@
-shared_examples_for '.only' do |matching_filter, missing_filter|
+shared_examples_for '.only' do |matching_filter, expected_matches, missing_filter: nil|
   describe '.only' do
     def repository_only(vcr_cassette, filter)
       repository = described_class.new
@@ -16,14 +16,16 @@ shared_examples_for '.only' do |matching_filter, missing_filter|
       it{ is_expected.to have(expected_entries).entries }
     end
 
-    context "with no matches" do
-      include_examples '.only response', 'filter_miss', 0 do
-        let(:filter){ missing_filter }
+    unless missing_filter.nil?
+      context "with no matches" do
+        include_examples '.only response', 'filter_miss', 0 do
+          let(:filter){ missing_filter }
+        end
       end
     end
 
-    context "with one match" do
-      include_examples '.only response', 'filter_hit', 1 do
+    context "with matches" do
+      include_examples '.only response', 'filter_hit', expected_matches do
         let(:filter){ matching_filter }
       end
     end

--- a/spec/fortnox/api/repositories/examples/search.rb
+++ b/spec/fortnox/api/repositories/examples/search.rb
@@ -1,4 +1,3 @@
-
 shared_examples_for '.search' do |attribute_hash_key_name, value|
   describe '.search' do
 

--- a/spec/fortnox/api/repositories/invoice_spec.rb
+++ b/spec/fortnox/api/repositories/invoice_spec.rb
@@ -10,6 +10,8 @@ require 'fortnox/api/repositories/examples/only'
 describe Fortnox::API::Repository::Invoice, order: :defined, integration: true do
   include_context 'environment'
 
+  include_examples '.save', :comments, { customer_number: 1 }
+
   # It is not possible to delete Invoces. Therefore, expected nr of Orders
   # when running .all will continue to increase.
   include_examples '.all', 12
@@ -17,8 +19,6 @@ describe Fortnox::API::Repository::Invoice, order: :defined, integration: true d
   include_examples '.find'
 
   include_examples '.search', :customername, 'Test'
-  
-  include_examples '.save', :comments, { customer_number: 1 }
 
-  include_examples '.only', :fullypaid, :unpaid
+  include_examples '.only', :fullypaid, 1, missing_filter: :unpaid
 end

--- a/spec/fortnox/api/repositories/order_spec.rb
+++ b/spec/fortnox/api/repositories/order_spec.rb
@@ -3,9 +3,11 @@ require 'fortnox/api/repositories/contexts/environment'
 require 'fortnox/api/repositories/order'
 require 'fortnox/api/repositories/examples/all'
 require 'fortnox/api/repositories/examples/find'
+require 'fortnox/api/repositories/examples/only'
 require 'fortnox/api/repositories/examples/save'
+require 'fortnox/api/repositories/examples/search'
 
-describe Fortnox::API::Repository::Order, order: :defined do
+describe Fortnox::API::Repository::Order, order: :defined, integration: true do
   include_context 'environment'
 
   include_examples '.save', :comments, { customer_number: 1 }
@@ -15,4 +17,8 @@ describe Fortnox::API::Repository::Order, order: :defined do
   include_examples '.all', 8
 
   include_examples '.find'
+
+  include_examples '.search', :customername, 'A customer'
+
+  include_examples '.only', :cancelled, 2
 end

--- a/spec/vcr_cassettes/orders/filter_hit.yml
+++ b/spec/vcr_cassettes/orders/filter_hit.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/orders/?filter=cancelled
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 28 Apr 2016 12:46:22 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '46'
+      X-Uid:
+      - 9a678044
+      X-Build:
+      - 8511f0b926
+    body:
+      encoding: UTF-8
+      string: '{"MetaInformation":{"@TotalResources":2,"@TotalPages":1,"@CurrentPage":1},"Orders":[{"@url":"https:\/\/api.fortnox.se\/3\/orders\/2","Cancelled":true,"Currency":"SEK","CustomerName":"An
+        updated value","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"2","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-20","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/3","Cancelled":true,"Currency":"SEK","CustomerName":"An
+        updated value","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"3","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-20","Project":"","Sent":false,"Total":0}]}'
+    http_version: 
+  recorded_at: Thu, 28 Apr 2016 12:46:22 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/orders/filter_invalid.yml
+++ b/spec/vcr_cassettes/orders/filter_invalid.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/orders/?filter=doesntexist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 28 Apr 2016 12:46:22 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      X-Rack-Responsetime:
+      - '29'
+      X-Uid:
+      - 7f438796
+      X-Build:
+      - 8511f0b926
+    body:
+      encoding: UTF-8
+      string: '{"ErrorInformation":{"error":1,"message":"Ett ogiltigt filter har anv\u00e4nts.","code":2000587}}'
+    http_version: 
+  recorded_at: Thu, 28 Apr 2016 12:46:22 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/orders/filter_miss.yml
+++ b/spec/vcr_cassettes/orders/filter_miss.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/orders/?filter=invoicenotcreated
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 28 Apr 2016 12:46:22 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '46'
+      X-Uid:
+      - 6c0c2332
+      X-Build:
+      - 8511f0b926
+    body:
+      encoding: UTF-8
+      string: '{"MetaInformation":{"@TotalResources":36,"@TotalPages":1,"@CurrentPage":1},"Orders":[{"@url":"https:\/\/api.fortnox.se\/3\/orders\/1","Cancelled":false,"Currency":"SEK","CustomerName":"An
+        updated value","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"1","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-20","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/4","Cancelled":false,"Currency":"SEK","CustomerName":"A
+        customer","CustomerNumber":"26","DeliveryDate":null,"DocumentNumber":"4","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-21","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/6","Cancelled":false,"Currency":"SEK","CustomerName":"An
+        updated value","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"6","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-21","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/7","Cancelled":false,"Currency":"SEK","CustomerName":"Updated
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"7","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-21","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/8","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"8","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-21","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/9","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"9","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-21","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/10","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"10","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-21","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/11","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"11","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-21","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/12","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"12","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-22","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/13","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"13","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-22","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/14","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"14","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-25","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/16","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"16","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-25","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/17","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"17","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-25","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/18","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"18","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-26","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/19","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"19","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/20","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"20","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/21","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"21","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/22","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"22","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/23","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"23","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/24","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"24","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/25","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"25","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/26","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"26","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/27","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"27","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/28","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"28","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/29","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"29","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":true,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/30","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"30","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/31","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"31","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/32","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"32","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/33","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"33","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/34","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"34","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/35","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"35","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/36","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"36","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/37","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"37","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/38","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"38","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/39","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"39","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-27","Project":"","Sent":false,"Total":0},{"@url":"https:\/\/api.fortnox.se\/3\/orders\/40","Cancelled":false,"Currency":"SEK","CustomerName":"Old
+        name","CustomerNumber":"1","DeliveryDate":null,"DocumentNumber":"40","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-28","Project":"","Sent":true,"Total":0}]}'
+    http_version: 
+  recorded_at: Thu, 28 Apr 2016 12:46:22 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/orders/search_by_name.yml
+++ b/spec/vcr_cassettes/orders/search_by_name.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/orders/?customername=A%20customer
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 28 Apr 2016 12:28:38 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '52'
+      X-Uid:
+      - 46b43188
+      X-Build:
+      - 8511f0b926
+    body:
+      encoding: UTF-8
+      string: '{"MetaInformation":{"@TotalResources":1,"@TotalPages":1,"@CurrentPage":1},"Orders":[{"@url":"https:\/\/api.fortnox.se\/3\/orders\/4","Cancelled":false,"Currency":"SEK","CustomerName":"A
+        customer","CustomerNumber":"26","DeliveryDate":null,"DocumentNumber":"4","ExternalInvoiceReference1":"","ExternalInvoiceReference2":"","OrderDate":"2016-04-21","Project":"","Sent":false,"Total":0}]}'
+    http_version: 
+  recorded_at: Thu, 28 Apr 2016 12:28:38 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/orders/search_miss.yml
+++ b/spec/vcr_cassettes/orders/search_miss.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/orders/?customername=nothing
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 28 Apr 2016 12:23:13 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '38'
+      X-Uid:
+      - a2bba74b
+      X-Build:
+      - 8511f0b926
+    body:
+      encoding: UTF-8
+      string: '{"MetaInformation":{"@TotalResources":0,"@TotalPages":0,"@CurrentPage":1},"Orders":[]}'
+    http_version: 
+  recorded_at: Thu, 28 Apr 2016 12:23:13 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
Spec for Repository::Order now includes both shared examples groups
'.search' and '.only'. These groups had to be refactored to
make it work. For instance, there is no filter for Order that
returns no hit, so that test was omitted for Order.