### PR TITLE
Fixes #67

### DIFF
--- a/lib/fortnox/api/models/customer.rb
+++ b/lib/fortnox/api/models/customer.rb
@@ -25,7 +25,8 @@ module Fortnox
         # )
 
         #Url	Direct URL to the record
-        attribute :url, String, writer: :private
+        # TODO: Writer should be private!
+        attribute :url, String
 
         #Address1	First address of the customer
         attribute :address1, String

--- a/lib/fortnox/api/models/document_base.rb
+++ b/lib/fortnox/api/models/document_base.rb
@@ -9,13 +9,15 @@ module Fortnox
         # rubocop:disable Metrics/MethodLength
         def self.included(base)
           # Url Direct url to the record.
-          base.attribute :url, String, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :url, String
 
           # AdministrationFee The document administration fee. 12 digits (incl. decimals)
           base.attribute :administration_fee, Float
 
           # AdministrationFeeVAT VAT of the document administration fee.
-          base.attribute :administration_fee_vat, Float, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :administration_fee_vat, Float
 
           # Address1 Document address 1. 1024 characters
           base.attribute :address1, String
@@ -24,10 +26,12 @@ module Fortnox
           base.attribute :address2, String
 
           # BasisTaxReduction Basis of tax reduction.
-          base.attribute :basis_tax_reduction, Float, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :basis_tax_reduction, Float
 
           # Cancelled If the document is cancelled.
-          base.attribute :cancelled, base::Boolean, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :cancelled, base::Boolean
 
           # City City for the document address.
           base.attribute :city, String
@@ -36,10 +40,12 @@ module Fortnox
           base.attribute :comments, String
 
           # ContributionPercent Document contribution in percent.
-          base.attribute :contribution_percent, Float, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :contribution_percent, Float
 
           # ContributionValue Document contribution in amount.
-          base.attribute :contribution_value, Float, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :contribution_value, Float
 
           # Country Country for the document address.
           base.attribute :country, String
@@ -99,26 +105,32 @@ module Fortnox
           base.attribute :freight, Float
 
           # FreightVAT VAT of the freight cost.
-          base.attribute :freight_vat, Float, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :freight_vat, Float
 
           # Gross Gross value of the document
-          base.attribute :gross, Float, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :gross, Float
 
           # HouseWork If there is any row of the document marked “house work”.
-          base.attribute :house_work, base::Boolean, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :house_work, base::Boolean
 
           # Net Net amount
-          base.attribute :net, Float, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :net, Float
 
           # NotCompleted If the document is set as not completed.
           base.attribute :not_completed, base::Boolean
 
           # OfferReference Reference to the offer, if one exists.
-          base.attribute :offer_reference, Integer, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :offer_reference, Integer
 
           # OrganisationNumber Organisation number of the customer for the
           # document.
-          base.attribute :organisation_number, String, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :organisation_number, String
 
           # OurReference Our reference. 50 characters
           base.attribute :our_reference, String
@@ -142,13 +154,16 @@ module Fortnox
           base.attribute :remarks, String
 
           # RoundOff Round off amount for the document.
-          base.attribute :round_off, Float, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :round_off, Float
 
           # Sent If the document is printed or sent in any way.
-          base.attribute :sent, base::Boolean, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :sent, base::Boolean
 
           # TaxReduction The amount of tax reduction.
-          base.attribute :tax_reduction, Integer, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :tax_reduction, Integer
 
           # TermsOfDelivery Code of the terms of delivery.
           base.attribute :terms_of_delivery, String
@@ -157,10 +172,12 @@ module Fortnox
           base.attribute :terms_of_payment, String
 
           # Total The total amount of the document.
-          base.attribute :total, Float, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :total, Float
 
           # TotalVAT The total VAT amount of the document.
-          base.attribute :total_vat, Float, writer: :private
+          # TODO: Writer should be private!
+          base.attribute :total_vat, Float
 
           # VATIncluded If the price of the document is including VAT.
           base.attribute :vat_included, base::Boolean

--- a/lib/fortnox/api/models/document_row.rb
+++ b/lib/fortnox/api/models/document_row.rb
@@ -26,10 +26,12 @@ module Fortnox
           base.attribute :article_number, String
 
           #ContributionPercent Contribution Percent.
-          base.attribute :contribution_percent, Float, writer: :private
+          #TODO: Writer should be private!
+          base.attribute :contribution_percent, Float
 
           #ContributionValue Contribution Value.
-          base.attribute :contribution_value, Float, writer: :private
+          #TODO: Writer should be private!
+          base.attribute :contribution_value, Float
 
           #CostCenter Code of the cost center for the row.
           base.attribute :cost_center, String
@@ -65,7 +67,8 @@ module Fortnox
           base.attribute :project, String
 
           #Total Total amount for the row.
-          base.attribute :total, Float, writer: :private
+          #TODO: Writer should be private!
+          base.attribute :total, Float
 
           #Unit Code of the unit for the row.
           base.attribute :unit, String

--- a/lib/fortnox/api/models/invoice.rb
+++ b/lib/fortnox/api/models/invoice.rb
@@ -9,25 +9,30 @@ module Fortnox
         include DocumentBase
 
         #UrlTaxReductionList Direct url to the tax reduction for the invoice.
-        attribute :url_tax_reduction_list, String, writer: :private
+        #TODO: Writer should be private!
+        attribute :url_tax_reduction_list, String
 
         #AccountingMethod Accounting Method.
         attribute :accounting_method, String
 
         #Balance Balance of the invoice.
-        attribute :balance, Float, writer: :private
+        #TODO: Writer should be private!
+        attribute :balance, Float
 
         #Booked If the invoice is bookkept.
-        attribute :booked, Boolean, writer: :private
+        #TODO: Writer should be private!
+        attribute :booked, Boolean
 
         #Credit If the invoice is a credit invoice.
-        attribute :credit, Boolean, writer: :private
+        #TODO: Writer should be private!
+        attribute :credit, Boolean
 
         #CreditInvoiceReference Reference to the credit invoice, if one exits.
         attribute :credit_invoice_reference, Integer
 
         #ContractReference Reference to the contract, if one exists.
-        attribute :contract_reference, Integer, writer: :private
+        #TODO: Writer should be private!
+        attribute :contract_reference, Integer
 
         #DueDate Due date of the invoice.
         attribute :due_date, Date
@@ -42,10 +47,12 @@ module Fortnox
         attribute :invoice_date, Date
 
         #InvoicePeriodStart Start date of the invoice period.
-        attribute :invoice_period_start, Date, writer: :private
+        #TODO: Writer should be private!
+        attribute :invoice_period_start, Date
 
         #InvoicePeriodEnd End date of the invoice period.
-        attribute :invoice_period_end, Date, writer: :private
+        #TODO: Writer should be private!
+        attribute :invoice_period_end, Date
 
         #InvoiceRows Separate object
         attribute :invoice_rows, Array[InvoiceRow]
@@ -57,28 +64,35 @@ module Fortnox
         attribute :language, String
 
         #LastRemindDate Date of last reminder.
-        attribute :last_remind_date, Date, writer: :private
+        #TODO: Writer should be private!
+        attribute :last_remind_date, Date
 
         #NoxFinans If the invoice is managed by NoxFinans
-        attribute :nox_finans, Boolean, writer: :private
+        #TODO: Writer should be private!
+        attribute :nox_finans, Boolean
 
         #OCR OCR number of the invoice.
         attribute :ocr, String
 
         #OrderReference Reference to the order, if one exists.
-        attribute :order_reference, Integer, writer: :private
+        #TODO: Writer should be private!
+        attribute :order_reference, Integer
 
         #Reminders Number of reminders sent to the customer.
-        attribute :reminders, Integer, writer: :private
+        #TODO: Writer should be private!
+        attribute :reminders, Integer
 
         #VoucherNumber Voucher number for the invoice.
-        attribute :voucher_number, Integer, writer: :private
+        #TODO: Writer should be private!
+        attribute :voucher_number, Integer
 
         #VoucherSeries Voucher series for the invoice.
-        attribute :voucher_series, String, writer: :private
+        #TODO: Writer should be private!
+        attribute :voucher_series, String
 
         #VoucherYear Voucher year for the invoice.
-        attribute :voucher_year, Integer, writer: :private
+        #TODO: Writer should be private!
+        attribute :voucher_year, Integer
       end
     end
   end

--- a/lib/fortnox/api/models/invoice_row.rb
+++ b/lib/fortnox/api/models/invoice_row.rb
@@ -7,10 +7,12 @@ module Fortnox
         include DocumentRow
 
         #PriceExcludingVAT Price per unit excluding VAT.
-        attribute :price_excluding_vat, Float, writer: :private
+        #TODO: Writer should be private!
+        attribute :price_excluding_vat, Float
 
         #TotalExcludingVAT  Total amount for the row excluding VAT.
-        attribute :total_excluding_vat, Float, writer: :private
+        #TODO: Writer should be private!
+        attribute :total_excluding_vat, Float
       end
     end
   end

--- a/lib/fortnox/api/models/order.rb
+++ b/lib/fortnox/api/models/order.rb
@@ -11,7 +11,8 @@ module Fortnox
         attribute :copy_remarks, Boolean
 
         # InvoiceReference Reference if an invoice is created from order
-        attribute :invoice_reference, Integer, writer: :private
+        # TODO: Writer should be private!
+        attribute :invoice_reference, Integer
 
         # OrderDate Date of order
         attribute :order_date, Date


### PR DESCRIPTION
Removes all private writers on attributes since they are not working.
Instead of just making the writer private, it prevents the attributes
to be set at all. (See #50). This is obviously a quick fix...