### PR TITLE
Introduce rubocop rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -988,6 +988,11 @@ Style/SpaceInsideRangeLiteral:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals'
   Enabled: false
 
+Style/SpaceInsideStringInterpolation:
+  Description: 'This cop checks for whitespace within string interpolations.'
+  EnforcedStyle: space
+  Enabled: true
+
 Style/SpecialGlobalVars:
   Description: 'Avoid Perl-style global variables.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,8 @@
 require: rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
+  DisplayCopNames: true
 
 #################### Lint ################################
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
+require: rubocop-rspec
+
 AllCops:
-  DisabledByDefault: true
   TargetRubyVersion: 2.1
 
 #################### Lint ################################
@@ -976,11 +977,10 @@ Style/SpaceInsideHashLiteralBraces:
   EnforcedStyleForEmptyBraces: no_space
   Enabled: true
 
-# Style/SpaceInsideParens:
-#   Description: 'Require spaces after ( or before ).'
-#   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
-#   EnforcedStyle: space
-#   Enabled: true
+Style/SpaceInsideParens:
+  Description: 'Require spaces after ( or before ).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
+  Enabled: false
 
 Style/SpaceInsideRangeLiteral:
   Description: 'No spaces inside range literals.'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1107,3 +1107,10 @@ Style/WordArray:
   Description: 'Use %w or %W for arrays of words.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-w'
   Enabled: false
+
+#################### RSpec ################################
+RSpec/FilePath:
+  Enabled: false
+
+RSpec/NestedGroups:
+    MaxNesting: 4

--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,5 @@
 guard :rspec, cmd: 'bundle exec rspec --color', all_after_pass: true do
   watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/(.+)\.rb$}){ |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^lib/(.+)\.rb$}){ |m| "spec/#{ m[1] }_spec.rb" }
   watch('spec/spec_helper.rb'){ "spec" }
 end

--- a/fortnox-api.gemspec
+++ b/fortnox-api.gemspec
@@ -34,5 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0"
   spec.add_development_dependency "rubocop", "~> 0.41"
+  spec.add_development_dependency "rubocop-rspec", "~> 1.7"
 
 end

--- a/lib/fortnox/api/base.rb
+++ b/lib/fortnox/api/base.rb
@@ -17,9 +17,9 @@ module Fortnox
       DEFAULT_HEADERS = {
         'Content-Type' => 'application/json',
         'Accept' => 'application/json',
-      }
+      }.freeze
 
-      HTTP_METHODS = [ :get, :put, :post, :delete ]
+      HTTP_METHODS = [ :get, :put, :post, :delete ].freeze
 
       attr_accessor :headers
 

--- a/lib/fortnox/api/models/base.rb
+++ b/lib/fortnox/api/models/base.rb
@@ -9,7 +9,7 @@ module Fortnox
         attr_accessor :unsaved
 
         def self.attribute( name, *args )
-          define_method( "#{name}?" ) do
+          define_method( "#{ name }?" ) do
             !send( name ).nil?
           end
 

--- a/lib/fortnox/api/models/base.rb
+++ b/lib/fortnox/api/models/base.rb
@@ -49,7 +49,7 @@ module Fortnox
           @saved
         end
 
-      private
+      private_class_method
 
         # dry-types filter anything that isn't specified as an attribute on the
         # class that is being instansiated. This wrapper preserves the meta
@@ -67,6 +67,8 @@ module Fortnox
 
           return obj
         end
+
+      private
 
         def private_attributes
           @@private_attributes ||= attribute_set.select{ |a| !a.public_writer? }

--- a/lib/fortnox/api/repositories/base/json_convertion.rb
+++ b/lib/fortnox/api/repositories/base/json_convertion.rb
@@ -30,11 +30,11 @@ module Fortnox
 
         def default_key_from_json_transform( key )
           key = key.to_s
-          return key.downcase if key.match(/\A[A-Z]+\z/)
+          return key.downcase if key =~ /\A[A-Z]+\z/
           key.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').
-          gsub(/([a-z])([A-Z])/, '\1_\2').
-          downcase.
-          to_sym
+            gsub(/([a-z])([A-Z])/, '\1_\2').
+            downcase.
+            to_sym
         end
 
         def convert_hash_keys_to_json_format( hash, key_map )

--- a/lib/fortnox/api/repositories/base/loaders.rb
+++ b/lib/fortnox/api/repositories/base/loaders.rb
@@ -41,7 +41,7 @@ module Fortnox
         end
 
         def find_one_by( id )
-          response_hash = get( "#{@options.uri}#{id}" )
+          response_hash = get( "#{ @options.uri }#{ id }" )
           entity_hash = response_hash[ @options.json_entity_wrapper ]
           hash_to_entity( entity_hash, @options.json_to_attr_map )
         end
@@ -57,7 +57,7 @@ module Fortnox
         end
 
         def escape( key, value )
-          "#{CGI.escape(key.to_s)}=#{CGI.escape(value.to_s)}"
+          "#{ CGI.escape(key.to_s) }=#{ CGI.escape(value.to_s) }"
         end
 
       end

--- a/lib/fortnox/api/request_handling.rb
+++ b/lib/fortnox/api/request_handling.rb
@@ -24,9 +24,9 @@ module Fortnox
           response.parsed_response
         end
 
-        def execute &request
+        def execute
           self.class.set_headers( @headers )
-          response = request.call( self.class )
+          response = yield( self.class )
           validate_and_parse response
         end
 

--- a/lib/fortnox/api/request_handling.rb
+++ b/lib/fortnox/api/request_handling.rb
@@ -7,7 +7,7 @@ module Fortnox
         def raise_api_error( error, response )
           message = ( error[ 'message' ] || error[ 'Message' ] || 'Okänt fel' )
 
-          message += "\n\n#{response.request.inspect}" if Fortnox::API.debugging
+          message += "\n\n#{ response.request.inspect }" if Fortnox::API.debugging
 
           raise Fortnox::API::RemoteServerError, message
         end

--- a/lib/fortnox/api/types.rb
+++ b/lib/fortnox/api/types.rb
@@ -6,7 +6,7 @@ module Fortnox
     module Types
       include Dry::Types.module
 
-      THE_TRUTH = { true => true, 'true' => true, false => false, 'false' => false }
+      THE_TRUTH = { true => true, 'true' => true, false => false, 'false' => false }.freeze
 
       require 'fortnox/api/types/required'
       require 'fortnox/api/types/defaulted'

--- a/lib/fortnox/api/version.rb
+++ b/lib/fortnox/api/version.rb
@@ -1,5 +1,5 @@
 module Fortnox
   module API
-    VERSION = "0.1.0"
+    VERSION = "0.1.0".freeze
   end
 end

--- a/spec/fortnox/api/base_spec.rb
+++ b/spec/fortnox/api/base_spec.rb
@@ -5,7 +5,7 @@ describe Fortnox::API::Base do
 
   describe 'creation' do
 
-    subject{ ->{ Fortnox::API::Base.new() } }
+    subject{ ->{ described_class.new() } }
 
     context 'without FORTNOX_API_BASE_URL' do
       before{ ENV['FORTNOX_API_BASE_URL'] = nil }
@@ -53,7 +53,7 @@ describe Fortnox::API::Base do
       )
     end
 
-    subject{ Fortnox::API::Base.new.get( '/test', { body: '' }) }
+    subject{ described_class.new.get( '/test', { body: '' }) }
 
     it{ is_expected.to be_nil }
   end
@@ -125,14 +125,14 @@ describe Fortnox::API::Base do
       )
     end
 
-    subject{ ->{ Fortnox::API::Base.new.post( '/test', { body: '' }) } }
+    subject{ ->{ described_class.new.post( '/test', { body: '' }) } }
 
     it{ is_expected.to raise_error( Fortnox::API::RemoteServerError ) }
     it{ is_expected.to raise_error( 'Räkenskapsår finns inte upplagt. För att kunna skapa en faktura krävs det att det finns ett räkenskapsår' ) }
 
     context 'with debugging enabled' do
 
-      around(:each) do |example|
+      around do |example|
         Fortnox::API.debugging = true
         example.run
         Fortnox::API.debugging = false

--- a/spec/fortnox/api/base_spec.rb
+++ b/spec/fortnox/api/base_spec.rb
@@ -96,15 +96,22 @@ describe Fortnox::API::Base do
       )
     end
 
-    it 'works' do
-      api = described_class.new
-      response1 = api.get( '/test', { body: '' })
-      response2 = api.get( '/test', { body: '' })
-      response3 = api.get( '/test', { body: '' })
+    let!(:api){ described_class.new }
+    let!(:response1){ api.get( path, body: '' ) }
+    let!(:response2){ api.get( path, body: '' ) }
+    let!(:response3){ api.get( path, body: '' ) }
 
-      expect( response1 ).not_to eq( response2 )
-      expect( response3 ).not_to eq( response2 )
-      expect( response1 ).to eq( response3 )
+    let(:path){ '/test' }
+
+    describe 'first request' do
+      subject{ response1 }
+      it{ is_expected.not_to eq( response2 ) }
+      it{ is_expected.to eq( response3 ) }
+    end
+
+    describe 'third request' do
+      subject{ response3 }
+      it{ is_expected.not_to eq( response2 ) }
     end
   end
 

--- a/spec/fortnox/api/base_spec.rb
+++ b/spec/fortnox/api/base_spec.rb
@@ -97,13 +97,13 @@ describe Fortnox::API::Base do
     end
 
     it 'works' do
-      api = Fortnox::API::Base.new
+      api = described_class.new
       response1 = api.get( '/test', { body: '' })
       response2 = api.get( '/test', { body: '' })
       response3 = api.get( '/test', { body: '' })
 
-      expect( response1 ).to_not eq( response2 )
-      expect( response3 ).to_not eq( response2 )
+      expect( response1 ).not_to eq( response2 )
+      expect( response3 ).not_to eq( response2 )
       expect( response1 ).to eq( response3 )
     end
   end

--- a/spec/fortnox/api/models/base_spec.rb
+++ b/spec/fortnox/api/models/base_spec.rb
@@ -17,7 +17,7 @@ describe Fortnox::API::Model::Base do
 
       it{ is_expected.to be_a Entity }
       it{ is_expected.to be_new }
-      it{ is_expected.to_not be_saved }
+      it{ is_expected.not_to be_saved }
     end
   end
 
@@ -28,7 +28,7 @@ describe Fortnox::API::Model::Base do
       subject{ original.update( string: 'Variant' ) }
 
       it 'returns a new object' do
-        is_expected.to_not eql( original )
+        is_expected.not_to eql( original )
       end
 
       it 'returns a object of the same class' do
@@ -40,7 +40,7 @@ describe Fortnox::API::Model::Base do
       end
 
       it{ is_expected.to be_new }
-      it{ is_expected.to_not be_saved }
+      it{ is_expected.not_to be_saved }
     end
 
     context 'with the same, simple value' do
@@ -55,7 +55,7 @@ describe Fortnox::API::Model::Base do
       end
 
       it{ is_expected.to be_new }
-      it{ is_expected.to_not be_saved }
+      it{ is_expected.not_to be_saved }
     end
 
     context 'a saved entity' do
@@ -64,13 +64,13 @@ describe Fortnox::API::Model::Base do
       subject{ saved_entry.update( string: 'Updated' ) }
 
       before do
-        expect(saved_entry).to_not be_new
+        expect(saved_entry).not_to be_new
         expect(saved_entry).to be_saved
       end
 
       specify{ expect(subject.string).to eq( 'Updated' ) }
-      it{ is_expected.to_not be_new }
-      it{ is_expected.to_not be_saved }
+      it{ is_expected.not_to be_new }
+      it{ is_expected.not_to be_saved }
     end
   end
 

--- a/spec/fortnox/api/models/base_spec.rb
+++ b/spec/fortnox/api/models/base_spec.rb
@@ -25,33 +25,37 @@ describe Fortnox::API::Model::Base do
     let(:original){ Entity.new( string: 'Test' ) }
 
     context 'with new, simple value' do
-      subject{ original.update( string: 'Variant' ) }
+      subject{ updated_model }
+
+      let(:updated_model){ original.update( string: 'Variant' ) }
+
+      it{ is_expected.to be_new }
+      it{ is_expected.not_to be_saved }
 
       it 'returns a new object' do
         is_expected.not_to eql( original )
       end
 
-      it 'returns a object of the same class' do
-        expect( subject.class ).to eql( original.class )
+      describe 'updated attribute' do
+        subject{ updated_model.string }
+        it{ is_expected.to eql( 'Variant' ) }
       end
 
-      it 'returns a object with the new value' do
-        expect( subject.string ).to eql( 'Variant' )
+      describe 'returned class' do
+        subject{ updated_model.class }
+        it{ is_expected.to eql( original.class ) }
       end
-
-      it{ is_expected.to be_new }
-      it{ is_expected.not_to be_saved }
     end
 
     context 'with the same, simple value' do
-      subject{ original.update( string: 'Test' ) }
+      subject( :updated_model ){ original.update( string: 'Test' ) }
 
       it 'returns the same object' do
         is_expected.to eql( original )
       end
 
       it 'returns a object with the same value' do
-        expect( subject.string ).to eql( 'Test' )
+        expect( updated_model.string ).to eql( 'Test' )
       end
 
       it{ is_expected.to be_new }
@@ -59,16 +63,16 @@ describe Fortnox::API::Model::Base do
     end
 
     context 'a saved entity' do
-      let( :saved_entry ){ Entity.new( string: 'Saved', new: false, unsaved: false) }
+      subject( :updated_entry ){ saved_entry.update( string: 'Updated' ) }
 
-      subject{ saved_entry.update( string: 'Updated' ) }
+      let( :saved_entry ){ Entity.new( string: 'Saved', new: false, unsaved: false) }
 
       before do
         expect(saved_entry).not_to be_new
         expect(saved_entry).to be_saved
       end
 
-      specify{ expect(subject.string).to eq( 'Updated' ) }
+      specify{ expect(updated_entry.string).to eq( 'Updated' ) }
       it{ is_expected.not_to be_new }
       it{ is_expected.not_to be_saved }
     end

--- a/spec/fortnox/api/models/context.rb
+++ b/spec/fortnox/api/models/context.rb
@@ -1,6 +1,6 @@
 shared_context 'models context' do
   shared_examples 'having value objects' do |value_object_class|
-    context "when having a(n) #{value_object_class}" do
+    context "when having a(n) #{ value_object_class }" do
       it "returns the correct object" do
         value_object = value_object_class.new
         invoice = described_class.new( customer_number: '123', attribute => value_object )

--- a/spec/fortnox/api/models/examples/document_base.rb
+++ b/spec/fortnox/api/models/examples/document_base.rb
@@ -31,7 +31,7 @@ shared_examples_for 'DocumentBase Model' do |row_class, row_attribute, valid_has
 
   it{ is_expected.to have_currency( :currency, valid_hash ) }
 
-  context "when having a(n) #{row_class}" do
+  context "when having a(n) #{ row_class }" do
     it 'returns the correct object' do
       row = row_class.new(valid_row_hash)
       document_base = described_class.new( customer_number: '123', row_attribute => [row] )

--- a/spec/fortnox/api/repositories/contexts/environment.rb
+++ b/spec/fortnox/api/repositories/contexts/environment.rb
@@ -1,7 +1,7 @@
 require 'fortnox/api'
 
 shared_context 'environment' do
-  before(:each) do
+  before do
     ENV['FORTNOX_API_BASE_URL'] = 'https://api.fortnox.se/3'
     ENV['FORTNOX_API_CLIENT_SECRET'] = '9aBA8ZgsvR'
     ENV['FORTNOX_API_ACCESS_TOKEN'] = 'ccaef817-d5d8-4b1c-a316-54f3e55c5c54'

--- a/spec/fortnox/api/repositories/examples/all.rb
+++ b/spec/fortnox/api/repositories/examples/all.rb
@@ -1,7 +1,7 @@
 shared_examples_for '.all' do |count|
   describe '.all' do
     let(:response) do
-      VCR.use_cassette( "#{vcr_dir}/all" ){ subject.all }
+      VCR.use_cassette( "#{ vcr_dir }/all" ){ subject.all }
     end
 
     specify 'returns correct number of records' do

--- a/spec/fortnox/api/repositories/examples/all.rb
+++ b/spec/fortnox/api/repositories/examples/all.rb
@@ -1,4 +1,5 @@
-shared_examples_for '.all' do |count|
+# rubocop:disable RSpec/DescribeClass
+RSpec.shared_examples_for '.all' do |count|
   describe '.all' do
     let(:response) do
       VCR.use_cassette( "#{ vcr_dir }/all" ){ subject.all }
@@ -13,3 +14,4 @@ shared_examples_for '.all' do |count|
     end
   end
 end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/fortnox/api/repositories/examples/find.rb
+++ b/spec/fortnox/api/repositories/examples/find.rb
@@ -1,3 +1,4 @@
+# rubocop:disable RSpec/NamedSubject
 shared_examples_for '.find' do
   let( :find_id ){ 1 }
   let( :find_id_1 ) do
@@ -26,3 +27,4 @@ shared_examples_for '.find' do
     end
   end
 end
+# rubocop:enable RSpec/NamedSubject

--- a/spec/fortnox/api/repositories/examples/find.rb
+++ b/spec/fortnox/api/repositories/examples/find.rb
@@ -1,7 +1,7 @@
 shared_examples_for '.find' do
   let( :find_id ){ 1 }
   let( :find_id_1 ) do
-    VCR.use_cassette( "#{vcr_dir}/find_id_1" ){ subject.find( find_id ) }
+    VCR.use_cassette( "#{ vcr_dir }/find_id_1" ){ subject.find( find_id ) }
   end
 
   describe '.find' do
@@ -22,7 +22,7 @@ shared_examples_for '.find' do
     end
 
     specify 'returned Customer is not markes as new' do
-      expect( find_id_1 ).to_not be_new
+      expect( find_id_1 ).not_to be_new
     end
   end
 end

--- a/spec/fortnox/api/repositories/examples/only.rb
+++ b/spec/fortnox/api/repositories/examples/only.rb
@@ -1,3 +1,4 @@
+# rubocop:disable RSpec/DescribeClass
 shared_examples_for '.only' do |matching_filter, expected_matches, missing_filter: nil|
   describe '.only' do
     def repository_only(vcr_cassette, filter)
@@ -40,3 +41,4 @@ shared_examples_for '.only' do |matching_filter, expected_matches, missing_filte
     end
   end
 end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/fortnox/api/repositories/examples/only.rb
+++ b/spec/fortnox/api/repositories/examples/only.rb
@@ -3,7 +3,7 @@ shared_examples_for '.only' do |matching_filter, expected_matches, missing_filte
     def repository_only(vcr_cassette, filter)
       repository = described_class.new
 
-      VCR.use_cassette( "#{vcr_dir}/#{vcr_cassette}" ) do
+      VCR.use_cassette( "#{ vcr_dir }/#{ vcr_cassette }" ) do
         repository.only( filter )
       end
     end

--- a/spec/fortnox/api/repositories/examples/save.rb
+++ b/spec/fortnox/api/repositories/examples/save.rb
@@ -9,7 +9,7 @@ shared_examples_for '.save' do |attribute_hash_name, required_attributes = {}|
       required_attributes.merge( attribute_hash_name => value )
     end
     let( :new_model ){ described_class::MODEL.new( new_hash ) }
-    let( :save_new ){ VCR.use_cassette( "#{vcr_dir}/save_new" ){ subject.save( new_model ) } }
+    let( :save_new ){ VCR.use_cassette( "#{ vcr_dir }/save_new" ){ subject.save( new_model ) } }
     let( :entity_wrapper ){ subject.options.json_entity_wrapper }
     let( :value ){ 'A value' }
 
@@ -17,18 +17,16 @@ shared_examples_for '.save' do |attribute_hash_name, required_attributes = {}|
       before do
         if model.saved?
           message = 'Test trying to save model, but already marked as saved!'
-          message << " Model: #{model.inspect}"
+          message << " Model: #{ model.inspect }"
           fail(message)
         end
       end
 
-      specify "includes correct #{attribute_hash_name.inspect}" do
+      specify "includes correct #{ attribute_hash_name.inspect }" do
         response = send_request
-        attribute_json_name = Fortnox::API::Repository::JSONConvertion
-          .convert_key_to_json(
-            attribute_hash_name,
-            subject.options.attr_to_json_map
-          )
+        attribute_json_name =
+          Fortnox::API::Repository::JSONConvertion.convert_key_to_json( attribute_hash_name,
+                                                                        subject.options.attr_to_json_map )
         expect( response[entity_wrapper][attribute_json_name] ).to eql( value )
       end
     end
@@ -41,7 +39,7 @@ shared_examples_for '.save' do |attribute_hash_name, required_attributes = {}|
         end
       end
 
-      context "saved #{described_class::MODEL}" do
+      context "saved #{ described_class::MODEL }" do
         let( :repository ){ described_class.new }
         let( :hash ){ { unsaved: false }.merge(new_hash) }
         let( :model ){ described_class::MODEL.new( hash ) }
@@ -52,20 +50,20 @@ shared_examples_for '.save' do |attribute_hash_name, required_attributes = {}|
           expect( repository ).not_to receive( :update_existing )
         end
 
-        specify{ expect( repository.save( model )).to eql( true ) }
+        specify{ expect( repository.save( model )).to be( true ) }
       end
     end
 
     describe 'old (update existing)' do
       include_examples 'save' do
-        let( :value ){ "Updated #{attribute_hash_name}" }
+        let( :value ){ "Updated #{ attribute_hash_name }" }
         let( :model ) do
           new_id = save_new[entity_wrapper][subject.options.unique_id]
-          new_record = VCR.use_cassette( "#{vcr_dir}/find_new" ){ subject.find( new_id ) }
+          new_record = VCR.use_cassette( "#{ vcr_dir }/find_new" ){ subject.find( new_id ) }
           new_record.update( attribute_hash_name => value )
         end
         let( :send_request ) do
-          VCR.use_cassette( "#{vcr_dir}/save_old" ){ subject.save( model ) }
+          VCR.use_cassette( "#{ vcr_dir }/save_old" ){ subject.save( model ) }
         end
       end
     end

--- a/spec/fortnox/api/repositories/examples/save.rb
+++ b/spec/fortnox/api/repositories/examples/save.rb
@@ -1,3 +1,4 @@
+# rubocop:disable RSpec/DescribeClass
 #######################################
 # SPEC IS DEPENDENT ON DEFINED ORDER!
 #######################################
@@ -69,3 +70,4 @@ shared_examples_for '.save' do |attribute_hash_name, required_attributes = {}|
     end
   end
 end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/fortnox/api/repositories/examples/save.rb
+++ b/spec/fortnox/api/repositories/examples/save.rb
@@ -1,4 +1,4 @@
-# rubocop:disable RSpec/DescribeClass
+# rubocop:disable RSpec/DescribeClass, RSpec/NamedSubject
 #######################################
 # SPEC IS DEPENDENT ON DEFINED ORDER!
 #######################################
@@ -70,4 +70,4 @@ shared_examples_for '.save' do |attribute_hash_name, required_attributes = {}|
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass
+# rubocop:enable RSpec/DescribeClass, RSpec/NamedSubject

--- a/spec/fortnox/api/repositories/examples/save_with_nested_model.rb
+++ b/spec/fortnox/api/repositories/examples/save_with_nested_model.rb
@@ -6,7 +6,7 @@ shared_examples_for '.save with nested model' do |required_hash, nested_key, nes
     required_hash.merge( nested_key => nested_hash )
   end
   let( :response ) do
-    VCR.use_cassette( "#{vcr_dir}/save_with_nested_model" ) do
+    VCR.use_cassette( "#{ vcr_dir }/save_with_nested_model" ) do
       model = described_class::MODEL.new( new_hash )
       repository.save( model )
     end

--- a/spec/fortnox/api/repositories/examples/search.rb
+++ b/spec/fortnox/api/repositories/examples/search.rb
@@ -8,7 +8,7 @@ shared_examples_for '.search' do |attribute_hash_key_name, value|
 
       context "with no matches" do
         subject do
-          VCR.use_cassette( "#{vcr_dir}/search_miss" ) do
+          VCR.use_cassette( "#{ vcr_dir }/search_miss" ) do
             repository.search( attribute_hash_key_name => 'nothing' )
           end
         end
@@ -19,7 +19,7 @@ shared_examples_for '.search' do |attribute_hash_key_name, value|
 
       context "with one match" do
         subject do
-          VCR.use_cassette( "#{vcr_dir}/search_by_name" ) do
+          VCR.use_cassette( "#{ vcr_dir }/search_by_name" ) do
             repository.search( attribute_hash_key_name => value )
           end
         end

--- a/spec/fortnox/api/repositories/examples/search.rb
+++ b/spec/fortnox/api/repositories/examples/search.rb
@@ -1,3 +1,4 @@
+# rubocop:disable RSpec/DescribeClass
 shared_examples_for '.search' do |attribute_hash_key_name, value|
   describe '.search' do
 
@@ -31,3 +32,4 @@ shared_examples_for '.search' do |attribute_hash_key_name, value|
     end
   end
 end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/fortnox/api/types/account_number_spec.rb
+++ b/spec/fortnox/api/types/account_number_spec.rb
@@ -3,28 +3,26 @@ require 'fortnox/api/types'
 require 'fortnox/api/types/examples/types'
 
 describe Fortnox::API::Types do
-  describe 'AccountNumber' do
-    let( :described_class ){ Fortnox::API::Types::AccountNumber }
+  let( :klass ){ Fortnox::API::Types::AccountNumber }
 
-    context 'created with nil' do
-      subject{ described_class[ nil ] }
-      it{ is_expected.to be_nil }
-    end
+  context 'AccountNumber created with nil' do
+    subject{ klass[ nil ] }
+    it{ is_expected.to be_nil }
+  end
 
-    context 'created with empty string' do
-      include_examples 'raises ConstraintError', ''
-    end
+  context 'AccountNumber created with empty string' do
+    include_examples 'raises ConstraintError', ''
+  end
 
-    context 'created with valid number' do
-      include_examples 'equals input', 1234
-    end
+  context 'AccountNumber created with valid number' do
+    include_examples 'equals input', 1234
+  end
 
-    context 'created with a too large number' do
-      include_examples 'raises ConstraintError', 10000
-    end
+  context 'AccountNumber created with a too large number' do
+    include_examples 'raises ConstraintError', 10000
+  end
 
-    context 'created with a negative number' do
-      include_examples 'raises ConstraintError', -1
-    end
+  context 'AccountNumber created with a negative number' do
+    include_examples 'raises ConstraintError', -1
   end
 end

--- a/spec/fortnox/api/types/email_spec.rb
+++ b/spec/fortnox/api/types/email_spec.rb
@@ -3,29 +3,27 @@ require 'fortnox/api/types'
 require 'fortnox/api/types/examples/types'
 
 describe Fortnox::API::Types do
-  describe 'Email' do
-    let( :described_class ){ Fortnox::API::Types::Email }
+  let( :klass ){ Fortnox::API::Types::Email }
 
-    context 'created with nil' do
-      subject{ described_class[ nil ] }
-      it{ is_expected.to be_nil }
-    end
+  context 'Email created with nil' do
+    subject{ klass[ nil ] }
+    it{ is_expected.to be_nil }
+  end
 
-    context 'created with empty string' do
-      subject{ described_class[ '' ] }
-      it{ is_expected.to eq('') }
-    end
+  context 'Email created with empty string' do
+    subject{ klass[ '' ] }
+    it{ is_expected.to eq('') }
+  end
 
-    context 'created with valid email' do
-      let( :input ){ 'test@example.com' }
-      subject{ described_class[ input ] }
-      it{ is_expected.to eq input }
-    end
+  context 'Email created with valid email' do
+    subject{ klass[ input ] }
+    let( :input ){ 'test@example.com' }
+    it{ is_expected.to eq input }
+  end
 
-    context 'created with more than 1024 characters' do
-      legal_characters = 'abcdefghijklmnopqrstuvwxyz-_+'.split('')
-      too_long_email = (legal_characters * 35).shuffle.join + '@example.com'
-      include_examples 'raises ConstraintError', too_long_email
-    end
+  context 'Email created with more than 1024 characters' do
+    legal_characters = 'abcdefghijklmnopqrstuvwxyz-_+'.split('')
+    too_long_email = (legal_characters * 35).shuffle.join + '@example.com'
+    include_examples 'raises ConstraintError', too_long_email
   end
 end

--- a/spec/fortnox/api/types/examples/enum.rb
+++ b/spec/fortnox/api/types/examples/enum.rb
@@ -2,17 +2,17 @@ require 'fortnox/api/types/examples/types'
 
 shared_examples_for 'enum' do |name, values, auto_crop: false|
   describe name do
-    let( :described_class ){ Fortnox::API::Types.const_get(name) }
+    let( :klass ){ Fortnox::API::Types.const_get(name) }
 
     context 'created with nil' do
-      subject{ described_class[ nil ] }
+      subject{ klass[ nil ] }
       it{ is_expected.to be_nil }
     end
 
     context 'created with' do
-      let( :enum_value ){ Fortnox::API::Types.const_get(values).values.sample }
+      subject{ klass[ input ] }
 
-      subject{ described_class[ input ] }
+      let( :enum_value ){ Fortnox::API::Types.const_get(values).values.sample }
 
       context 'a random member from then enum' do
         let(:input){ enum_value }
@@ -35,7 +35,7 @@ shared_examples_for 'enum' do |name, values, auto_crop: false|
         if auto_crop
           it{ is_expected.to eq enum_value }
         else
-          subject{ ->{ described_class[ input ] } }
+          subject{ ->{ klass[ input ] } }
           it{ is_expected.to raise_error(Dry::Types::ConstraintError) }
         end
       end

--- a/spec/fortnox/api/types/examples/types.rb
+++ b/spec/fortnox/api/types/examples/types.rb
@@ -1,9 +1,9 @@
 shared_examples_for 'equals input' do |input|
-  subject{ described_class[ input ] }
+  subject{ klass[ input ] }
   it{ is_expected.to eq input }
 end
 
 shared_examples_for 'raises ConstraintError' do |input|
-  subject{ ->{ described_class[ input ] } }
+  subject{ ->{ klass[ input ] } }
   it{ is_expected.to raise_error(Dry::Types::ConstraintError) }
 end

--- a/spec/fortnox/api/types/model_spec.rb
+++ b/spec/fortnox/api/types/model_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Fortnox::API::Types::Model do
       it{ is_expected.to raise_error(Dry::Struct::Error) }
     end
 
-    describe "User inheriting from #{described_class}" do
+    describe "User inheriting from #{ described_class }" do
       subject{ ->{ TypesModelUser.new(args) } }
 
       it{ is_expected.to raise_error(Dry::Struct::Error) }

--- a/spec/fortnox/api/types/sized_spec.rb
+++ b/spec/fortnox/api/types/sized_spec.rb
@@ -6,14 +6,14 @@ describe Fortnox::API::Types::Sized do
 
   shared_examples_for 'Sized Types' do
     context 'created with nil' do
-      subject{ described_class[ nil ] }
+      subject{ klass[ nil ] }
       it{ is_expected.to be_nil }
     end
   end
 
   describe 'String' do
     max_size = 5
-    let( :described_class ){ Fortnox::API::Types::Sized::String[ max_size ] }
+    let( :klass ){ described_class::String[ max_size ] }
 
     it_behaves_like 'Sized Types'
 
@@ -35,7 +35,7 @@ describe Fortnox::API::Types::Sized do
   end
 
   shared_examples_for 'Sized Numeric' do |type, min, max, step|
-    let( :described_class ){ described_class.const_get(type)[ min, max ] }
+    let( :klass ){ described_class.const_get(type)[ min, max ] }
 
     it_behaves_like 'Sized Types'
 

--- a/spec/fortnox/api/types/sized_spec.rb
+++ b/spec/fortnox/api/types/sized_spec.rb
@@ -35,7 +35,7 @@ describe Fortnox::API::Types::Sized do
   end
 
   shared_examples_for 'Sized Numeric' do |type, min, max, step|
-    let( :described_class ){ Fortnox::API::Types::Sized.const_get(type)[ min, max ] }
+    let( :described_class ){ described_class.const_get(type)[ min, max ] }
 
     it_behaves_like 'Sized Types'
 

--- a/spec/fortnox/api_spec.rb
+++ b/spec/fortnox/api_spec.rb
@@ -9,9 +9,7 @@ describe Fortnox::API do
       ENV['FORTNOX_API_CLIENT_SECRET'] = 'P5K5vE3Kun'
       ENV['FORTNOX_API_ACCESS_TOKEN'] = '3f08d038-f380-4893-94a0-a08f6e60e67a'
       ENV['FORTNOX_API_AUTHORIZATION_CODE'] = 'ea3862b0-189c-464b-8e23-1b9702365ea1'
-    end
 
-    it 'works' do
       stub_request(
         :get,
         'http://api.fortnox.se/3/',
@@ -21,16 +19,16 @@ describe Fortnox::API do
           'Client-Secret' => 'P5K5vE3Kun',
           'Accept' => 'application/json',
         }
-      ).to_return(
-        status: 200,
-        body: { 'Authorisation' => { 'AccessToken' => '3f08d038-f380-4893-94a0-a08f6e60e67a' } }.to_json,
-        headers: { 'Content-Type' => 'application/json' },
-      )
-
-      response = described_class.get_access_token
-
-      expect( response).to eql( "3f08d038-f380-4893-94a0-a08f6e60e67a" )
+        ).to_return(
+          status: 200,
+          body: { 'Authorisation' => { 'AccessToken' => '3f08d038-f380-4893-94a0-a08f6e60e67a' } }.to_json,
+          headers: { 'Content-Type' => 'application/json' },
+        )
     end
-  end
 
+
+    subject{ described_class.get_access_token }
+
+    it{ is_expected.to eql( "3f08d038-f380-4893-94a0-a08f6e60e67a" ) }
+  end
 end

--- a/spec/fortnox/api_spec.rb
+++ b/spec/fortnox/api_spec.rb
@@ -27,7 +27,7 @@ describe Fortnox::API do
         headers: { 'Content-Type' => 'application/json' },
       )
 
-      response = Fortnox::API.get_access_token
+      response = described_class.get_access_token
 
       expect( response).to eql( "3f08d038-f380-4893-94a0-a08f6e60e67a" )
     end

--- a/spec/support/matchers/model/attribute_matcher.rb
+++ b/spec/support/matchers/model/attribute_matcher.rb
@@ -13,19 +13,19 @@ module Matchers
       end
 
       def description
-        "have #{@attribute_type} attribute #{@attribute.inspect}"
+        "have #{ @attribute_type } attribute #{ @attribute.inspect }"
       end
 
       def failure_message
-        "Expected class to have attribute #{@attribute.inspect} defined as #{@attribute_type}, "\
+        "Expected class to have attribute #{ @attribute.inspect } defined as #{ @attribute_type }, "\
         "but got following errors: 
-        #{@errors}"
+        #{ @errors }"
       end
 
       protected
 
-        def expect_error(msg, &block)
-          block.call
+        def expect_error(msg)
+          yield
 
           @errors << msg
           false # Fail test since expected error not thrown

--- a/spec/support/matchers/model/enum_matcher.rb
+++ b/spec/support/matchers/model/enum_matcher.rb
@@ -7,7 +7,7 @@ module Matchers
         super( attribute, valid_hash, attr_type, valid_value, nonsense_value )
 
         @enum_type = Fortnox::API::Types.const_get(enum_type)
-        @expected_error = "Exception missing for nonsense value #{@invalid_value.inspect}"
+        @expected_error = "Exception missing for nonsense value #{ @invalid_value.inspect }"
       end
 
       private

--- a/spec/support/matchers/model/have_account_number_matcher.rb
+++ b/spec/support/matchers/model/have_account_number_matcher.rb
@@ -7,7 +7,7 @@ module Matchers
     class HaveAccountNumberMatcher < TypeMatcher
       def initialize( attribute, valid_hash )
         super( attribute, valid_hash, 'account number', 1000, -1 )
-        @expected_error = "Exception missing for invalid value #{@invalid_value.inspect}".freeze
+        @expected_error = "Exception missing for invalid value #{ @invalid_value.inspect }".freeze
       end
 
       private

--- a/spec/support/matchers/model/have_email_matcher.rb
+++ b/spec/support/matchers/model/have_email_matcher.rb
@@ -7,7 +7,7 @@ module Matchers
     class HaveEmailMatcher < TypeMatcher
       def initialize( attribute, valid_hash )
         super( attribute, valid_hash, 'email', 'valid@email.com', 'invalid@email_without_top_domain' )
-        @expected_error = "Exception missing for invalid value #{@invalid_value.inspect}"
+        @expected_error = "Exception missing for invalid value #{ @invalid_value.inspect }"
         @expected_type = Fortnox::API::Types::Email
       end
 

--- a/spec/support/matchers/model/have_nullable_string_matcher.rb
+++ b/spec/support/matchers/model/have_nullable_string_matcher.rb
@@ -32,13 +32,13 @@ module Matchers
           non_string = 10.0
           @klass.new( @valid_hash.merge( @attribute => non_string ) )
         rescue Dry::Struct::Error => error
-          expected_message = "#{non_string.inspect} (#{non_string.class}) "\
-                             "has invalid type for #{@attribute.inspect}"
+          expected_message = "#{ non_string.inspect } (#{ non_string.class }) "\
+                             "has invalid type for #{ @attribute.inspect }"
           if error.message.include?(expected_message)
             return true
           else
-            fail_message = "Expected error message to include #{expected_message.inspect}, "\
-                           "but was #{error.message.inspect}"
+            fail_message = "Expected error message to include #{ expected_message.inspect }, "\
+                           "but was #{ error.message.inspect }"
             fail(fail_message)
           end
 

--- a/spec/support/matchers/model/have_sized_string_matcher.rb
+++ b/spec/support/matchers/model/have_sized_string_matcher.rb
@@ -25,7 +25,7 @@ module Matchers
         def rejects_too_long_string?
           too_long = @max_size + 1
           too_long_string = 'a' * too_long
-          expect_error("Exception missing for too long string (#{too_long} characters)") do
+          expect_error("Exception missing for too long string (#{ too_long } characters)") do
             @klass.new( @valid_hash.merge( @attribute => too_long_string ) )
           end
         end

--- a/spec/support/matchers/model/numeric_matcher.rb
+++ b/spec/support/matchers/model/numeric_matcher.rb
@@ -22,7 +22,7 @@ module Matchers
 
         def rejects_too_small_value?
           too_small_value = @min_value - @step
-          expected_error_message = "Exception missing for too small value (#{too_small_value})"
+          expected_error_message = "Exception missing for too small value (#{ too_small_value })"
           rejects_value?(too_small_value, expected_error_message)
         end
 
@@ -36,7 +36,7 @@ module Matchers
 
         def rejects_too_big_value?
           too_big_value = @max_value + @step
-          expected_error_message = "Exception missing for too big value (#{too_big_value})"
+          expected_error_message = "Exception missing for too big value (#{ too_big_value })"
           rejects_value?(too_big_value, expected_error_message)
         end
 

--- a/spec/support/matchers/model/require_attribute_matcher.rb
+++ b/spec/support/matchers/model/require_attribute_matcher.rb
@@ -40,13 +40,13 @@ module Matchers
         end
 
         def no_exception_failure_message
-          "Expected class to raise #{EXCEPTION} "\
-          "when attribute #{@attribute.inspect} is missing."
+          "Expected class to raise #{ EXCEPTION } "\
+          "when attribute #{ @attribute.inspect } is missing."
         end
 
         def wrong_error_message
-          "Expected exception to equal #{expected_error_message.inspect}. "\
-          "Message was #{@wrong_error_message.inspect}."
+          "Expected exception to equal #{ expected_error_message.inspect }. "\
+          "Message was #{ @wrong_error_message.inspect }."
         end
     end
   end

--- a/spec/support/matchers/model/type_matcher.rb
+++ b/spec/support/matchers/model/type_matcher.rb
@@ -19,7 +19,7 @@ module Matchers
         def correct_type?
           return true if expected_type?
 
-          @errors << "Attribute #{@attribute.inspect} was expected to be of type #{@attribute_type}, but was #{@actual_type}"
+          @errors << "Attribute #{ @attribute.inspect } was expected to be of type #{ @attribute_type }, but was #{ @actual_type }"
           return false
         end
 

--- a/spec/support/matchers/shared/require_attribute_matcher.rb
+++ b/spec/support/matchers/shared/require_attribute_matcher.rb
@@ -17,19 +17,19 @@ module Matchers
       end
 
       def description
-        "require attribute #{@attribute.inspect}"
+        "require attribute #{ @attribute.inspect }"
       end
 
       private
 
         def no_exception_failure_message
-          "Expected class to raise #{EXCEPTION} "\
-          "when attribute #{@attribute.inspect} is missing."
+          "Expected class to raise #{ EXCEPTION } "\
+          "when attribute #{ @attribute.inspect } is missing."
         end
 
         def wrong_error_message
-          "Expected exception to equal #{expected_error_message.inspect}. "\
-          "Message was #{@wrong_error_message.inspect}."
+          "Expected exception to equal #{ expected_error_message.inspect }. "\
+          "Message was #{ @wrong_error_message.inspect }."
         end
     end
   end

--- a/spec/support/matchers/type/have_nullable_matcher.rb
+++ b/spec/support/matchers/type/have_nullable_matcher.rb
@@ -10,8 +10,8 @@ module Matchers
         @valid_value = valid_value
         @invalid_value = invalid_value
         @expected_error ||= Dry::Struct::Error
-        @expected_error_message ||= "#{@invalid_value.inspect} (#{@invalid_value.class}) "\
-                                    "has invalid type for #{@attribute.inspect}"
+        @expected_error_message ||= "#{ @invalid_value.inspect } (#{ @invalid_value.class }) "\
+                                    "has invalid type for #{ @attribute.inspect }"
       end
 
       def matches?( klass )
@@ -21,11 +21,11 @@ module Matchers
       end
 
       def description
-        "have nullable attribute #{@attribute.inspect}"
+        "have nullable attribute #{ @attribute.inspect }"
       end
 
       def failure_message
-        "Expected class to have nullable attribute #{@attribute.inspect}"
+        "Expected class to have nullable attribute #{ @attribute.inspect }"
       end
 
       private
@@ -45,8 +45,8 @@ module Matchers
           if error.message == @expected_error_message
             return true
           else
-            fail_message = "Expected error message to include #{expected_message.inspect}, "\
-                           "but was #{error.message.inspect}"
+            fail_message = "Expected error message to include #{ expected_message.inspect }, "\
+                           "but was #{ error.message.inspect }"
             fail(fail_message)
           end
         end

--- a/spec/support/matchers/type/require_attribute_matcher.rb
+++ b/spec/support/matchers/type/require_attribute_matcher.rb
@@ -36,7 +36,7 @@ module Matchers
         end
 
         def expected_error_message
-          "[#{@klass}.new] #{@attribute.inspect} is missing in Hash input"
+          "[#{ @klass }.new] #{ @attribute.inspect } is missing in Hash input"
         end
     end
   end


### PR DESCRIPTION
Introduces rubocop-rspec, a Rubocop engine for RSpec.

We recently merged a branch that had `focus: true` set on one test, which meant only that test in the whole test suite was run... This sadly lead to a merge with failing code to `development` branch. rubocop-rspec will check things like this for us :) Unfortunately, this means that tests will not pass in this branch, since `development` runs failing code. In my opinion, the failing tests should not be fixed in this branch. This should only include rubocop-rspec to our project. I'll vote for dealing with the failing specs in another branch.

This commit includes a lot of fixes for Rubocop violations among our specs.