### PR TITLE
Fixes bug in Fortnox::API::Base

### DIFF
--- a/lib/fortnox/api/base.rb
+++ b/lib/fortnox/api/base.rb
@@ -37,7 +37,7 @@ module Fortnox
           execute do |remote|
             response = remote.send( method, *args )
             self.headers['Access-Token'] = get_access_token
-            return response
+            response
           end
         end
       end

--- a/spec/fortnox/api/base_spec.rb
+++ b/spec/fortnox/api/base_spec.rb
@@ -96,15 +96,15 @@ describe Fortnox::API::Base do
       )
     end
 
-    it 'works', focus: true do
+    it 'works' do
       api = Fortnox::API::Base.new
       response1 = api.get( '/test', { body: '' })
       response2 = api.get( '/test', { body: '' })
       response3 = api.get( '/test', { body: '' })
 
-      expect( response1.parsed_response ).to_not eq( response2.parsed_response )
-      expect( response3.parsed_response ).to_not eq( response2.parsed_response )
-      expect( response1.parsed_response ).to eq( response3.parsed_response )
+      expect( response1 ).to_not eq( response2 )
+      expect( response3 ).to_not eq( response2 )
+      expect( response1 ).to eq( response3 )
     end
   end
 


### PR DESCRIPTION
Fixes bug in Fortnox::API::Base

Focused test in Fortnox::API::Base spec is removed.
When the focus was removed, three tests in Fortnox::API::Base spec was failing. I traced the bug to line 40 in Fortnox::API::Base. For some reason, response should not be returned here, or else no Exceptions are raised on remote server errors (500 response from Fortnox). I'll let @d-pixie have a look at this before merge...