### PR TITLE
Fixes #102 Locks down httparty version to 0.14.0

### DIFF
--- a/fortnox-api.gemspec
+++ b/fortnox-api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "httparty", "~> 0.13"
+  spec.add_dependency "httparty", "~> 0.14.0" # TODO: Temporary lockdown. See issue #103 for more info.
   spec.add_dependency "dotenv", "~> 2.0"
   spec.add_dependency "dry-struct", "~> 0.1"
   spec.add_dependency "dry-types", "~> 0.8"

--- a/fortnox-api.gemspec
+++ b/fortnox-api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ['> 2.2', '< 2.4'] # TODO: Gem breaks with Ruby 2.4 or higher
+  spec.required_ruby_version = ['> 2.2', '< 2.4'] # TODO: Gem breaks with Ruby 2.4 or higher. See issue #93.
 
   spec.add_dependency "httparty", "~> 0.14.0" # TODO: Temporary lockdown. See issue #103 for more info.
   spec.add_dependency "dotenv", "~> 2.0"

--- a/fortnox-api.gemspec
+++ b/fortnox-api.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '< 2.4' # TODO: Gem breaks with Ruby 2.4 or higher
+
   spec.add_dependency "httparty", "~> 0.14.0" # TODO: Temporary lockdown. See issue #103 for more info.
   spec.add_dependency "dotenv", "~> 2.0"
   spec.add_dependency "dry-struct", "~> 0.1"

--- a/fortnox-api.gemspec
+++ b/fortnox-api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '< 2.4' # TODO: Gem breaks with Ruby 2.4 or higher
+  spec.required_ruby_version = ['> 2.2', '< 2.4'] # TODO: Gem breaks with Ruby 2.4 or higher
 
   spec.add_dependency "httparty", "~> 0.14.0" # TODO: Temporary lockdown. See issue #103 for more info.
   spec.add_dependency "dotenv", "~> 2.0"


### PR DESCRIPTION
There were two failures with builds before:
1. httparty version 0.15.0 breaks some specs
2. Gem does not yet support Ruby version 2.4

The first issue is fixed with this PR. The other is not, but the Ruby version requirement is added to gemspec. (See issue #93 for Ruby 2.4 support).