### PR TITLE
Add Article resource

### DIFF
--- a/lib/fortnox/api/mappers/article.rb
+++ b/lib/fortnox/api/mappers/article.rb
@@ -1,0 +1,22 @@
+require "fortnox/api/mappers/base"
+
+module Fortnox
+  module API
+    module Mapper
+      class Article < Fortnox::API::Mapper::Base
+
+        KEY_MAP = {
+          ean: 'EAN',
+          eu_account: 'EUAccount',
+          eu_vat_account: 'EUVATAccount',
+          vat: 'VAT'
+        }.freeze
+        JSON_ENTITY_WRAPPER = 'Article'.freeze
+        JSON_COLLECTION_WRAPPER = 'Articles'.freeze
+
+      end
+
+      Registry.register( Article.canonical_name_sym, Article )
+    end
+  end
+end

--- a/lib/fortnox/api/models.rb
+++ b/lib/fortnox/api/models.rb
@@ -1,3 +1,4 @@
+require "fortnox/api/models/article"
 require "fortnox/api/models/customer"
 require "fortnox/api/models/invoice"
 require "fortnox/api/models/order"

--- a/lib/fortnox/api/models/article.rb
+++ b/lib/fortnox/api/models/article.rb
@@ -1,0 +1,133 @@
+require "fortnox/api/types"
+require "fortnox/api/models/base"
+
+module Fortnox
+  module API
+    module Model
+      class Article < Fortnox::API::Model::Base
+
+        UNIQUE_ID = :article_number
+        STUB = { description: '' }.freeze
+
+        #Url Direct URL to the record
+        attribute :url, Fortnox::API::Types::Nullable::String.with( read_only: true )
+
+        #Active If the article is active
+        attribute :active, Fortnox::API::Types::Nullable::Boolean
+
+        #ArticleNumber Article number. 50 characters
+        attribute :article_number, Fortnox::API::Types::Sized::String[ 50 ]
+
+        #Bulky If the article is bulky.
+        attribute :bulky, Fortnox::API::Types::Nullable::Boolean
+
+        #ConstructionAccount Account number for construction work (special VAT rules in Sweden).
+        # The number must be of an existing account.
+        attribute :construction_account, Types::Sized::Integer[ 0, 9_999 ]
+
+        #Depth The depth of the article in millimeters
+        attribute :depth, Types::Sized::Integer[ 0, 99_999_999 ]
+
+        #Description The description of the article
+        attribute :description, Fortnox::API::Types::Sized::String[ 200 ].with( required: true )
+
+        #DisposableQuantity Disposable quantity of the article.
+        attribute :disposable_quantity, Fortnox::API::Types::Nullable::Float.with( read_only: true )
+
+        #EAN EAN bar code
+        attribute :ean, Fortnox::API::Types::Sized::String[ 30 ]
+
+        #EUAccount Account number for the sales account to EU.
+        # The number must be of an existing account.
+        attribute :eu_account, Types::Sized::Integer[ 0, 9_999 ]
+
+        #EUVATAccount Account number for the sales account to EU with VAT.
+        # The number must be of an existing account.
+        attribute :eu_vat_account, Types::Sized::Integer[ 0, 9_999 ]
+
+        #ExportAccount Account number for the sales account outside EU
+        # The number must be of an existing account.
+        attribute :export_account, Types::Sized::Integer[ 0, 9_999 ]
+
+        #Height The height of the article in millimeters
+        attribute :height, Types::Sized::Integer[ 0, 99_999_999 ]
+
+        #Housework If the article is housework
+        attribute :housework, Fortnox::API::Types::Nullable::Boolean
+
+        #HouseWorkType The type of house work.
+        attribute :house_work_type, Types::HouseWorkType
+
+        #Manufacturer The manufacturer of the article
+        attribute :manufacturer, Fortnox::API::Types::Sized::String[ 50 ]
+
+        #ManufacturerArticleNumber The manufacturer's article number
+        attribute :manufacturer_article_number, Fortnox::API::Types::Sized::String[ 50 ]
+
+        #Note Text note
+        attribute :note, Fortnox::API::Types::Sized::String[ 10_000 ]
+
+        #PurchaseAccount Account number for purchase.
+        # The number must be of an existing account.
+        attribute :purchase_account, Types::Sized::Integer[ 0, 9_999 ]
+
+        #PurchasePrice Purchase price of the article
+        attribute :purchase_price, Fortnox::API::Types::Sized::Float[ 0.0, 99_999_999_999_999.9 ]
+
+        #QuantityInStock Quantity in stock of the article
+        attribute :quantity_in_stock, Fortnox::API::Types::Sized::Float[ 0.0, 99_999_999_999_999.9 ]
+
+        #ReservedQuantity Reserved quantity of the article
+        attribute :reserved_quantity, Fortnox::API::Types::Nullable::Float.with( read_only: true )
+
+        #SalesAccount Account number for the sales account in Sweden.
+        # The number must be of an existing account.
+        attribute :sales_account, Types::Sized::Integer[ 0, 9_999 ]
+
+        #SalesPrice Price of article for its default price list
+        attribute :sales_price, Fortnox::API::Types::Nullable::Float.with( read_only: true )
+
+        #StockGoods If the article is stock goods
+        attribute :stock_goods, Fortnox::API::Types::Nullable::Boolean
+
+        #StockPlace Storage place for the article
+        attribute :stock_place, Fortnox::API::Types::Sized::String[ 100 ]
+
+        #StockValue Value in stock of the article
+        attribute :stock_value, Fortnox::API::Types::Nullable::Float.with( read_only: true )
+
+        #StockWarning When to start warning for low quantity in stock
+        attribute :stock_warning, Fortnox::API::Types::Sized::Float[ 0.0, 99_999_999_999_999.9 ]
+
+        #SupplierName Name of the supplier
+        attribute :supplier_name, Fortnox::API::Types::Nullable::String.with( read_only: true )
+
+        #SupplierNumber Supplier number for the article.
+        # The number must be of an existing supplier.
+        attribute :supplier_number, Fortnox::API::Types::Nullable::String
+
+        #Type The type of the article
+        attribute :type, Types::ArticleType
+
+        #Unit Unit code for the article.
+        # The code must be of an existing unit.
+        attribute :unit, Fortnox::API::Types::Nullable::String
+
+        #VAT VAT percent, this is predefined by the VAT for the sales account
+        attribute :vat, Fortnox::API::Types::Nullable::Float
+
+        #WebshopArticle If the article is a webshop article
+        attribute :webshop_article, Fortnox::API::Types::Nullable::Boolean
+
+        #Weight Weight of the article in grams
+        attribute :weight, Types::Sized::Integer[ 0, 99_999_999 ]
+
+        #Width Width of the article in millimeters.
+        attribute :width, Types::Sized::Integer[ 0, 99_999_999 ]
+
+        #Expired If the article has expired
+        attribute :expired, Fortnox::API::Types::Nullable::Boolean
+      end
+    end
+  end
+end

--- a/lib/fortnox/api/repositories.rb
+++ b/lib/fortnox/api/repositories.rb
@@ -1,3 +1,4 @@
+require "fortnox/api/repositories/article"
 require "fortnox/api/repositories/customer"
 require "fortnox/api/repositories/invoice"
 require "fortnox/api/repositories/order"

--- a/lib/fortnox/api/repositories/article.rb
+++ b/lib/fortnox/api/repositories/article.rb
@@ -1,0 +1,16 @@
+require "fortnox/api/repositories/base"
+require "fortnox/api/models/article"
+require "fortnox/api/mappers/article"
+
+module Fortnox
+  module API
+    module Repository
+      class Article < Fortnox::API::Repository::Base
+
+        MODEL = Fortnox::API::Model::Article
+        MAPPER = Fortnox::API::Mapper::Article
+        URI = '/articles/'.freeze
+      end
+    end
+  end
+end

--- a/lib/fortnox/api/types.rb
+++ b/lib/fortnox/api/types.rb
@@ -18,6 +18,8 @@ module Fortnox
 
       AccountNumber = Strict::Int.constrained( gt: 0, lteq: 9999 ).optional
 
+      ArticleType = Strict::String.constrained( included_in: ArticleTypes.values ).optional.constructor( EnumConstructors.default )
+
       CountryCode = Strict::String.constrained( included_in: CountryCodes.values ).optional.constructor( EnumConstructors.sized(2) )
       Currency = Strict::String.constrained( included_in: Currencies.values ).optional.constructor( EnumConstructors.sized(3) )
       CustomerType = Strict::String.constrained( included_in: CustomerTypes.values ).optional.constructor( EnumConstructors.default )

--- a/lib/fortnox/api/types/enums.rb
+++ b/lib/fortnox/api/types/enums.rb
@@ -12,6 +12,9 @@ module Fortnox
         end
       end
 
+      ArticleTypes = Types::Strict::String.enum(
+        'SERVICE','STOCK'
+      )
       DiscountTypes = Types::Strict::String.enum(
         'AMOUNT','PERCENT'
       )

--- a/spec/fortnox/api/mappers/article_spec.rb
+++ b/spec/fortnox/api/mappers/article_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'fortnox/api'
+require 'fortnox/api/mappers/customer'
+require 'fortnox/api/mappers/examples/mapper'
+
+describe Fortnox::API::Mapper::Article do
+  key_map = Fortnox::API::Mapper::Article::KEY_MAP
+
+  json_entity_type = 'Article'
+  json_entity_collection = 'Articles'
+
+  it_behaves_like 'mapper', key_map, json_entity_type, json_entity_collection do
+    let(:mapper){ described_class.new }
+  end
+end

--- a/spec/fortnox/api/models/article_spec.rb
+++ b/spec/fortnox/api/models/article_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+require 'fortnox/api/models/article'
+require 'fortnox/api/models/examples/model'
+
+describe Fortnox::API::Model::Article, type: :model do
+  it_behaves_like 'a model', '1'
+end

--- a/spec/fortnox/api/repositories/article_spec.rb
+++ b/spec/fortnox/api/repositories/article_spec.rb
@@ -11,7 +11,9 @@ require 'fortnox/api/repositories/examples/search'
 describe Fortnox::API::Repository::Article, order: :defined, integration: true do
   subject(:repository){ described_class.new }
 
-  # include_examples '.save', :description
+  include_examples '.save',
+                   :description,
+                   additional_attrs: { sales_account: 1250 }
 
   include_examples '.save with specially named attribute',
                    { description: 'Test article' },

--- a/spec/fortnox/api/repositories/article_spec.rb
+++ b/spec/fortnox/api/repositories/article_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'fortnox/api'
+require 'fortnox/api/mappers'
+require 'fortnox/api/repositories/customer'
+require 'fortnox/api/repositories/examples/all'
+require 'fortnox/api/repositories/examples/find'
+require 'fortnox/api/repositories/examples/save'
+require 'fortnox/api/repositories/examples/save_with_specially_named_attribute'
+require 'fortnox/api/repositories/examples/search'
+
+describe Fortnox::API::Repository::Article, order: :defined, integration: true do
+  subject(:repository){ described_class.new }
+
+  # include_examples '.save', :description
+
+  include_examples '.save with specially named attribute',
+                   { description: 'Test article' },
+                   :ean,
+                   '5901234123457'
+
+  include_examples '.all', 12
+
+  include_examples '.find', '1' do
+    let( :find_by_hash_failure ){ { description: 'Not Found' } }
+    let( :single_param_find_by_hash ){ { find_hash: { articlenumber: 1 }, matches: 3 } }
+
+    let( :multi_param_find_by_hash ) do
+      { find_hash: { articlenumber: 1, description: 'Cykelpump' }, matches: 1 }
+    end
+  end
+
+  include_examples '.search', :description, 'Testartikel', 2
+end

--- a/spec/fortnox/api/repositories/examples/save.rb
+++ b/spec/fortnox/api/repositories/examples/save.rb
@@ -5,11 +5,9 @@
 # Assumes that attribute is a string attribute without restrictions.
 
 # rubocop:disable RSpec/DescribeClass
-shared_examples_for '.save' do |attribute, required_attributes = {}|
+shared_examples_for '.save' do |attribute, additional_attrs: {}|
   describe '.save' do
-    let( :new_hash ) do
-      required_attributes.merge( attribute => value )
-    end
+    let( :new_hash ){ additional_attrs.merge( attribute => value ) }
     let( :new_model ){ described_class::MODEL.new( new_hash ) }
     let( :save_new ){ VCR.use_cassette( "#{ vcr_dir }/save_new" ){ repository.save( new_model ) } }
     let( :entity_wrapper ){ repository.mapper.class::JSON_ENTITY_WRAPPER }

--- a/spec/fortnox/api/repositories/invoice_spec.rb
+++ b/spec/fortnox/api/repositories/invoice_spec.rb
@@ -15,7 +15,7 @@ describe Fortnox::API::Repository::Invoice, order: :defined, integration: true d
 
   required_hash = { customer_number: '1' }
 
-  include_examples '.save', :comments, required_hash
+  include_examples '.save', :comments, additional_attrs: required_hash
 
   nested_model_hash = { price: 10, article_number: '0000' }
   include_examples '.save with nested model',

--- a/spec/fortnox/api/repositories/order_spec.rb
+++ b/spec/fortnox/api/repositories/order_spec.rb
@@ -14,7 +14,7 @@ describe Fortnox::API::Repository::Order, order: :defined, integration: true do
 
   required_hash = { customer_number: '1' }
 
-  include_examples '.save', :comments, required_hash
+  include_examples '.save', :comments, additional_attrs: required_hash
 
   nested_model_hash = { price: 10, article_number: '0000', ordered_quantity: 1 }
   include_examples '.save with nested model',

--- a/spec/fortnox/api/repositories/project_spec.rb
+++ b/spec/fortnox/api/repositories/project_spec.rb
@@ -9,9 +9,9 @@ require 'fortnox/api/repositories/examples/save'
 describe Fortnox::API::Repository::Project, order: :defined, integration: true do
   subject( :repository ){ described_class.new }
 
-  required_attributes = { description: 'Some important project' }
-
-  include_examples '.save', :comments, required_attributes
+  include_examples '.save',
+                   :comments,
+                   additional_attrs: { description: 'Some important project' }
 
   # It is not yet possible to delete Projects. Therefore, expected nr of
   # Projects when running .all will continue to increase

--- a/spec/fortnox/api/types/enums_spec.rb
+++ b/spec/fortnox/api/types/enums_spec.rb
@@ -3,6 +3,7 @@ require 'fortnox/api/types'
 require 'fortnox/api/types/examples/enum'
 
 describe Fortnox::API::Types do
+  it_behaves_like 'enum', 'ArticleType', 'ArticleTypes'
   it_behaves_like 'enum', 'CountryCode', 'CountryCodes', auto_crop: true
   it_behaves_like 'enum', 'Currency', 'Currencies', auto_crop: true
   it_behaves_like 'enum', 'CustomerType', 'CustomerTypes'

--- a/spec/vcr_cassettes/articles/all.yml
+++ b/spec/vcr_cassettes/articles/all.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/articles/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 08 Oct 2017 21:51:31 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '21'
+      X-Uid:
+      - 1aa0352f
+      X-Build:
+      - e1392b4cf7
+    body:
+      encoding: UTF-8
+      string: '{"MetaInformation":{"@TotalResources":12,"@TotalPages":1,"@CurrentPage":1},"Articles":[{"@url":"https:\/\/api.fortnox.se\/3\/articles\/0000","ArticleNumber":"0000","Description":"Testartikel","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":null,"QuantityInStock":"0","ReservedQuantity":"0","StockPlace":"","StockValue":"0","Unit":null,"VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/0001","ArticleNumber":"0001","Description":"Cykelpump","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":"100","QuantityInStock":"0","ReservedQuantity":"0","StockPlace":"","StockValue":"0","Unit":null,"VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/1","ArticleNumber":"1","Description":"Testartikel","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":"100","QuantityInStock":"0","ReservedQuantity":"0","StockPlace":"","StockValue":"0","Unit":null,"VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/2","ArticleNumber":"2","Description":"A
+        value","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":null,"QuantityInStock":"0","ReservedQuantity":"0","StockPlace":null,"StockValue":"0","Unit":"","VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/3","ArticleNumber":"3","Description":"Test
+        article","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":null,"QuantityInStock":"0","ReservedQuantity":"0","StockPlace":null,"StockValue":"0","Unit":"","VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/4","ArticleNumber":"4","Description":"Test
+        article","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":null,"QuantityInStock":"0","ReservedQuantity":"0","StockPlace":null,"StockValue":"0","Unit":"","VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/5","ArticleNumber":"5","Description":"Test
+        article","DisposableQuantity":"0","EAN":"5901234123457","Housework":false,"PurchasePrice":"0","SalesPrice":null,"QuantityInStock":"0","ReservedQuantity":"0","StockPlace":null,"StockValue":"0","Unit":"","VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/6","ArticleNumber":"6","Description":"A
+        value","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":null,"QuantityInStock":"0","ReservedQuantity":"0","StockPlace":null,"StockValue":"0","Unit":"","VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/7","ArticleNumber":"7","Description":"Test
+        article","DisposableQuantity":"0","EAN":"5901234123457","Housework":false,"PurchasePrice":"0","SalesPrice":null,"QuantityInStock":"0","ReservedQuantity":"0","StockPlace":null,"StockValue":"0","Unit":"","VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/8","ArticleNumber":"8","Description":"A
+        value","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":null,"QuantityInStock":"0","ReservedQuantity":"0","StockPlace":null,"StockValue":"0","Unit":"","VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/9","ArticleNumber":"9","Description":"A
+        value","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":null,"QuantityInStock":"0","ReservedQuantity":"0","StockPlace":null,"StockValue":"0","Unit":"","VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/10","ArticleNumber":"10","Description":"Abc
+        123","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":null,"QuantityInStock":"0","ReservedQuantity":"0","StockPlace":null,"StockValue":"0","Unit":"","VAT":null,"WebshopArticle":false}]}'
+    http_version: 
+  recorded_at: Sun, 08 Oct 2017 21:51:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/articles/find_by_hash_failure.yml
+++ b/spec/vcr_cassettes/articles/find_by_hash_failure.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/articles/?description=Not%20Found
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 08 Oct 2017 21:51:44 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '20'
+      X-Uid:
+      - 4b1a3e1d
+      X-Build:
+      - e1392b4cf7
+    body:
+      encoding: UTF-8
+      string: '{"MetaInformation":{"@TotalResources":0,"@TotalPages":0,"@CurrentPage":1},"Articles":[]}'
+    http_version: 
+  recorded_at: Sun, 08 Oct 2017 21:51:44 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/articles/find_failure.yml
+++ b/spec/vcr_cassettes/articles/find_failure.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/articles/123456789
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 08 Oct 2017 21:51:44 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '20'
+      X-Uid:
+      - 9d7a18ed
+      X-Build:
+      - e1392b4cf7
+    body:
+      encoding: UTF-8
+      string: '{"ErrorInformation":{"Error":1,"Message":"Kan inte hitta artikeln.","Code":2000428}}'
+    http_version: 
+  recorded_at: Sun, 08 Oct 2017 21:51:44 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/articles/find_id_1.yml
+++ b/spec/vcr_cassettes/articles/find_id_1.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/articles/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 08 Oct 2017 21:51:43 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '32'
+      X-Uid:
+      - 8b796198
+      X-Build:
+      - e1392b4cf7
+    body:
+      encoding: UTF-8
+      string: '{"Article":{"@url":"https:\/\/api.fortnox.se\/3\/articles\/1","ArticleNumber":"1","Bulky":false,"ConstructionAccount":1030,"Depth":null,"Description":"Testartikel","DisposableQuantity":-163995.5,"EAN":"","EUAccount":1030,"EUVATAccount":1030,"ExportAccount":1030,"Height":null,"Housework":false,"HouseworkType":null,"Active":true,"Manufacturer":null,"ManufacturerArticleNumber":null,"Note":"","PurchaseAccount":1030,"PurchasePrice":0,"QuantityInStock":0,"ReservedQuantity":163995.5,"SalesAccount":1030,"StockGoods":false,"StockPlace":"","StockValue":0,"StockWarning":null,"SupplierName":null,"SupplierNumber":null,"Type":"STOCK","Unit":null,"VAT":0,"WebshopArticle":false,"Weight":null,"Width":null,"Expired":false,"SalesPrice":100,"CostCalculationMethod":null,"StockAccount":null,"StockChangeAccount":null,"DirectCost":0,"FreightCost":0,"OtherCost":0}}'
+    http_version: 
+  recorded_at: Sun, 08 Oct 2017 21:51:43 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/articles/find_new.yml
+++ b/spec/vcr_cassettes/articles/find_new.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/articles/18
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 09 Oct 2017 19:45:43 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '25'
+      X-Uid:
+      - 5191a93e
+      X-Build:
+      - 5228d322dc
+    body:
+      encoding: UTF-8
+      string: '{"Article":{"@url":"https:\/\/api.fortnox.se\/3\/articles\/18","ArticleNumber":"18","Bulky":false,"ConstructionAccount":0,"Depth":0,"Description":"A
+        value","DisposableQuantity":0,"EAN":"","EUAccount":3200,"EUVATAccount":3231,"ExportAccount":3200,"Height":0,"Housework":false,"HouseworkType":null,"Active":true,"Manufacturer":null,"ManufacturerArticleNumber":"","Note":"","PurchaseAccount":3100,"PurchasePrice":0,"QuantityInStock":0,"ReservedQuantity":0,"SalesAccount":1250,"StockGoods":false,"StockPlace":null,"StockValue":0,"StockWarning":0,"SupplierName":null,"SupplierNumber":null,"Type":"STOCK","Unit":null,"VAT":0,"WebshopArticle":false,"Weight":0,"Width":0,"Expired":false,"SalesPrice":null,"CostCalculationMethod":null,"StockAccount":null,"StockChangeAccount":null,"DirectCost":0,"FreightCost":0,"OtherCost":0}}'
+    http_version: 
+  recorded_at: Mon, 09 Oct 2017 19:45:43 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/articles/multi_param_find_by_hash.yml
+++ b/spec/vcr_cassettes/articles/multi_param_find_by_hash.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/articles/?articlenumber=1&description=Cykelpump
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 08 Oct 2017 21:51:44 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '25'
+      X-Uid:
+      - adbaf2f0
+      X-Build:
+      - e1392b4cf7
+    body:
+      encoding: UTF-8
+      string: '{"MetaInformation":{"@TotalResources":1,"@TotalPages":1,"@CurrentPage":1},"Articles":[{"@url":"https:\/\/api.fortnox.se\/3\/articles\/0001","ArticleNumber":"0001","Description":"Cykelpump","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":"100","QuantityInStock":"0","ReservedQuantity":"0","StockPlace":"","StockValue":"0","Unit":null,"VAT":null,"WebshopArticle":false}]}'
+    http_version: 
+  recorded_at: Sun, 08 Oct 2017 21:51:44 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/articles/save_new.yml
+++ b/spec/vcr_cassettes/articles/save_new.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.fortnox.se/3/articles/
+    body:
+      encoding: UTF-8
+      string: '{"Article":{"Description":"A value","SalesAccount":1250}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 09 Oct 2017 19:45:43 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Location:
+      - articles
+      X-Rack-Responsetime:
+      - '52'
+      X-Uid:
+      - a37e054e
+      X-Build:
+      - 5228d322dc
+    body:
+      encoding: UTF-8
+      string: '{"Article":{"@url":"https:\/\/api.fortnox.se\/3\/articles\/18","ArticleNumber":"18","Bulky":false,"ConstructionAccount":0,"Depth":0,"Description":"A
+        value","DisposableQuantity":0,"EAN":"","EUAccount":3200,"EUVATAccount":3231,"ExportAccount":3200,"Height":0,"Housework":false,"HouseworkType":null,"Active":true,"Manufacturer":null,"ManufacturerArticleNumber":"","Note":"","PurchaseAccount":3100,"PurchasePrice":0,"QuantityInStock":0,"ReservedQuantity":0,"SalesAccount":1250,"StockGoods":false,"StockPlace":null,"StockValue":0,"StockWarning":0,"SupplierName":null,"SupplierNumber":null,"Type":"STOCK","Unit":null,"VAT":0,"WebshopArticle":false,"Weight":0,"Width":0,"Expired":false,"SalesPrice":null,"CostCalculationMethod":null,"StockAccount":null,"StockChangeAccount":null,"DirectCost":0,"FreightCost":0,"OtherCost":0}}'
+    http_version: 
+  recorded_at: Mon, 09 Oct 2017 19:45:43 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/articles/save_old.yml
+++ b/spec/vcr_cassettes/articles/save_old.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.fortnox.se/3/articles/18
+    body:
+      encoding: UTF-8
+      string: '{"Article":{"Description":"Updated description"}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 09 Oct 2017 19:46:17 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '49'
+      X-Uid:
+      - 0f7a1484
+      X-Build:
+      - 5228d322dc
+    body:
+      encoding: UTF-8
+      string: '{"Article":{"@url":"https:\/\/api.fortnox.se\/3\/articles\/18","ArticleNumber":"18","Bulky":false,"ConstructionAccount":0,"Depth":0,"Description":"Updated
+        description","DisposableQuantity":0,"EAN":"","EUAccount":3200,"EUVATAccount":3231,"ExportAccount":3200,"Height":0,"Housework":false,"HouseworkType":null,"Active":true,"Manufacturer":null,"ManufacturerArticleNumber":"","Note":"","PurchaseAccount":3100,"PurchasePrice":0,"QuantityInStock":0,"ReservedQuantity":0,"SalesAccount":1250,"StockGoods":false,"StockPlace":null,"StockValue":0,"StockWarning":0,"SupplierName":null,"SupplierNumber":null,"Type":"STOCK","Unit":null,"VAT":0,"WebshopArticle":false,"Weight":0,"Width":0,"Expired":false,"SalesPrice":null,"CostCalculationMethod":null,"StockAccount":null,"StockChangeAccount":null,"DirectCost":0,"FreightCost":0,"OtherCost":0}}'
+    http_version: 
+  recorded_at: Mon, 09 Oct 2017 19:46:17 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/articles/save_with_specially_named_attribute.yml
+++ b/spec/vcr_cassettes/articles/save_with_specially_named_attribute.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.fortnox.se/3/articles/
+    body:
+      encoding: UTF-8
+      string: '{"Article":{"Description":"Test article","EAN":"5901234123457"}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 08 Oct 2017 22:07:12 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Location:
+      - articles
+      X-Rack-Responsetime:
+      - '26'
+      X-Uid:
+      - d3dadb1a
+      X-Build:
+      - e1392b4cf7
+    body:
+      encoding: UTF-8
+      string: '{"Article":{"@url":"https:\/\/api.fortnox.se\/3\/articles\/13","ArticleNumber":"13","Bulky":false,"ConstructionAccount":0,"Depth":0,"Description":"Test
+        article","DisposableQuantity":0,"EAN":"5901234123457","EUAccount":3200,"EUVATAccount":3231,"ExportAccount":3200,"Height":0,"Housework":false,"HouseworkType":null,"Active":true,"Manufacturer":null,"ManufacturerArticleNumber":"","Note":"","PurchaseAccount":3100,"PurchasePrice":0,"QuantityInStock":0,"ReservedQuantity":0,"SalesAccount":3011,"StockGoods":false,"StockPlace":null,"StockValue":0,"StockWarning":0,"SupplierName":null,"SupplierNumber":null,"Type":"STOCK","Unit":null,"VAT":0,"WebshopArticle":false,"Weight":0,"Width":0,"Expired":false,"SalesPrice":null,"CostCalculationMethod":null,"StockAccount":null,"StockChangeAccount":null,"DirectCost":0,"FreightCost":0,"OtherCost":0}}'
+    http_version: 
+  recorded_at: Sun, 08 Oct 2017 22:07:13 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/articles/save_with_specially_named_attribute.yml
+++ b/spec/vcr_cassettes/articles/save_with_specially_named_attribute.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 08 Oct 2017 22:07:12 GMT
+      - Mon, 09 Oct 2017 19:39:23 GMT
       Content-Type:
       - application/json
       Connection:
@@ -31,15 +31,15 @@ http_interactions:
       Location:
       - articles
       X-Rack-Responsetime:
-      - '26'
+      - '34'
       X-Uid:
-      - d3dadb1a
+      - 9213a3b9
       X-Build:
-      - e1392b4cf7
+      - 5228d322dc
     body:
       encoding: UTF-8
-      string: '{"Article":{"@url":"https:\/\/api.fortnox.se\/3\/articles\/13","ArticleNumber":"13","Bulky":false,"ConstructionAccount":0,"Depth":0,"Description":"Test
+      string: '{"Article":{"@url":"https:\/\/api.fortnox.se\/3\/articles\/16","ArticleNumber":"16","Bulky":false,"ConstructionAccount":0,"Depth":0,"Description":"Test
         article","DisposableQuantity":0,"EAN":"5901234123457","EUAccount":3200,"EUVATAccount":3231,"ExportAccount":3200,"Height":0,"Housework":false,"HouseworkType":null,"Active":true,"Manufacturer":null,"ManufacturerArticleNumber":"","Note":"","PurchaseAccount":3100,"PurchasePrice":0,"QuantityInStock":0,"ReservedQuantity":0,"SalesAccount":3011,"StockGoods":false,"StockPlace":null,"StockValue":0,"StockWarning":0,"SupplierName":null,"SupplierNumber":null,"Type":"STOCK","Unit":null,"VAT":0,"WebshopArticle":false,"Weight":0,"Width":0,"Expired":false,"SalesPrice":null,"CostCalculationMethod":null,"StockAccount":null,"StockChangeAccount":null,"DirectCost":0,"FreightCost":0,"OtherCost":0}}'
     http_version: 
-  recorded_at: Sun, 08 Oct 2017 22:07:13 GMT
+  recorded_at: Mon, 09 Oct 2017 19:39:23 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/articles/search_by_name.yml
+++ b/spec/vcr_cassettes/articles/search_by_name.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/articles/?description=Testartikel
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 08 Oct 2017 21:51:45 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '19'
+      X-Uid:
+      - d47a06a7
+      X-Build:
+      - e1392b4cf7
+    body:
+      encoding: UTF-8
+      string: '{"MetaInformation":{"@TotalResources":2,"@TotalPages":1,"@CurrentPage":1},"Articles":[{"@url":"https:\/\/api.fortnox.se\/3\/articles\/0000","ArticleNumber":"0000","Description":"Testartikel","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":null,"QuantityInStock":"0","ReservedQuantity":"0","StockPlace":"","StockValue":"0","Unit":null,"VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/1","ArticleNumber":"1","Description":"Testartikel","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":"100","QuantityInStock":"0","ReservedQuantity":"0","StockPlace":"","StockValue":"0","Unit":null,"VAT":null,"WebshopArticle":false}]}'
+    http_version: 
+  recorded_at: Sun, 08 Oct 2017 21:51:45 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/articles/search_miss.yml
+++ b/spec/vcr_cassettes/articles/search_miss.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/articles/?description=nothing
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 08 Oct 2017 21:51:45 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '21'
+      X-Uid:
+      - b37d7e6d
+      X-Build:
+      - e1392b4cf7
+    body:
+      encoding: UTF-8
+      string: '{"MetaInformation":{"@TotalResources":0,"@TotalPages":0,"@CurrentPage":1},"Articles":[]}'
+    http_version: 
+  recorded_at: Sun, 08 Oct 2017 21:51:45 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/articles/search_with_special_char.yml
+++ b/spec/vcr_cassettes/articles/search_with_special_char.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/articles/?description=special%20char%20%C3%A5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 08 Oct 2017 21:51:45 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '19'
+      X-Uid:
+      - 763e5b2a
+      X-Build:
+      - e1392b4cf7
+    body:
+      encoding: UTF-8
+      string: '{"MetaInformation":{"@TotalResources":0,"@TotalPages":0,"@CurrentPage":1},"Articles":[]}'
+    http_version: 
+  recorded_at: Sun, 08 Oct 2017 21:51:45 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/articles/single_param_find_by_hash.yml
+++ b/spec/vcr_cassettes/articles/single_param_find_by_hash.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.fortnox.se/3/articles/?articlenumber=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Client-Secret:
+      - 9aBA8ZgsvR
+      Access-Token:
+      - ccaef817-d5d8-4b1c-a316-54f3e55c5c54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 08 Oct 2017 21:51:44 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Responsetime:
+      - '30'
+      X-Uid:
+      - f74ca935
+      X-Build:
+      - e1392b4cf7
+    body:
+      encoding: UTF-8
+      string: '{"MetaInformation":{"@TotalResources":3,"@TotalPages":1,"@CurrentPage":1},"Articles":[{"@url":"https:\/\/api.fortnox.se\/3\/articles\/0001","ArticleNumber":"0001","Description":"Cykelpump","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":"100","QuantityInStock":"0","ReservedQuantity":"0","StockPlace":"","StockValue":"0","Unit":null,"VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/1","ArticleNumber":"1","Description":"Testartikel","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":"100","QuantityInStock":"0","ReservedQuantity":"0","StockPlace":"","StockValue":"0","Unit":null,"VAT":null,"WebshopArticle":false},{"@url":"https:\/\/api.fortnox.se\/3\/articles\/10","ArticleNumber":"10","Description":"Abc
+        123","DisposableQuantity":"0","EAN":"","Housework":false,"PurchasePrice":"0","SalesPrice":null,"QuantityInStock":"0","ReservedQuantity":"0","StockPlace":null,"StockValue":"0","Unit":"","VAT":null,"WebshopArticle":false}]}'
+    http_version: 
+  recorded_at: Sun, 08 Oct 2017 21:51:44 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Pleasantly easy to add this resource along with a new enum type! :)

I was unable to use the `'.save'` example group because Fortnox adds `EUAccount`, `EUVATAccount`, `ExportAccount`, `PurchaseAccount` and `SalesAccount` values that don't correspond to actual accounts, thus `'old (update existing)'` fails. Any ideas?
