### PR TITLE
Rubocop update refactoring

### DIFF
--- a/lib/fortnox/api/mappers/base/from_json.rb
+++ b/lib/fortnox/api/mappers/base/from_json.rb
@@ -72,10 +72,12 @@ module Fortnox
 
         def default_key_from_json_transform(key)
           key = key.to_s
-          unless key.match?(/\A[A-Z]+\z/)
-            key = key.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').gsub(/([a-z])([A-Z])/, '\1_\2')
-          end
+          key = camelCase_to_underscore(key) unless key =~ /\A[A-Z]+\z/
           key.downcase.to_sym
+        end
+
+        def camelCase_to_underscore(key)
+          key.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').gsub(/([a-z])([A-Z])/, '\1_\2')
         end
       end
     end

--- a/spec/fortnox/api/mappers/contexts/json_conversion.rb
+++ b/spec/fortnox/api/mappers/contexts/json_conversion.rb
@@ -46,9 +46,8 @@ shared_context 'with JSON conversion' do
     end
 
     def register_mapper(mapper_sym, mapper)
-      unless Fortnox::API::Registry.key? mapper_sym
-        Fortnox::API::Registry.register(mapper_sym, mapper)
-      end
+      return if Fortnox::API::Registry.key? mapper_sym
+      Fortnox::API::Registry.register(mapper_sym, mapper)
     end
 
     register_mapper(:category, Test::CategoryMapper)

--- a/spec/fortnox/api/models/base_spec.rb
+++ b/spec/fortnox/api/models/base_spec.rb
@@ -83,25 +83,23 @@ describe Fortnox::API::Model::Base do
       it { is_expected.not_to be_saved }
     end
 
-    context 'with a saved entity' do
-      subject { saved_entry }
+    context 'when updating' do
+      let(:updated_entity) do
+        saved_entity = Entity.new(string: 'Saved', new: false, unsaved: false)
+        saved_entity.update(string: 'Updated')
+      end
 
-      let(:saved_entry) { Entity.new(string: 'Saved', new: false, unsaved: false) }
-      let(:updated_entry) { saved_entry.update(string: 'Updated') }
-
-      describe 'returned entity' do
-        subject { updated_entry }
+      context 'updated entity' do
+        subject { updated_entity }
 
         it { is_expected.not_to be_saved }
         it { is_expected.not_to be_new }
       end
 
-      describe "returned entity's atttribute value" do
-        subject { updated_entry.string }
+      describe "updated attribute value" do
+        subject { updated_entity.string }
 
-        it 'is updated' do
-          is_expected.to eq('Updated')
-        end
+        it { is_expected.to eq('Updated') }
       end
     end
   end

--- a/spec/fortnox/api/models/base_spec.rb
+++ b/spec/fortnox/api/models/base_spec.rb
@@ -84,18 +84,30 @@ describe Fortnox::API::Model::Base do
     end
 
     context 'with a saved entity' do
-      subject(:updated_entry) { saved_entry.update(string: 'Updated') }
+      subject { saved_entry }
 
       let(:saved_entry) { Entity.new(string: 'Saved', new: false, unsaved: false) }
+      let(:updated_entry) { saved_entry.update(string: 'Updated') }
 
       before do
-        expect(saved_entry).not_to be_new
-        expect(saved_entry).to be_saved
+        raise 'Entity expected to be new!' if saved_entry.new?
+        raise 'Entity not expected to be saved!' unless saved_entry.saved?
       end
 
-      specify { expect(updated_entry.string).to eq('Updated') }
-      it { is_expected.not_to be_new }
-      it { is_expected.not_to be_saved }
+      describe 'returned entity' do
+        subject { updated_entry }
+
+        it { is_expected.not_to be_saved }
+        it { is_expected.not_to be_new }
+      end
+
+      describe "returned entity's atttribute value" do
+        subject { updated_entry.string }
+
+        it 'is updated' do
+          is_expected.to eq('Updated')
+        end
+      end
     end
   end
 end

--- a/spec/fortnox/api/models/base_spec.rb
+++ b/spec/fortnox/api/models/base_spec.rb
@@ -89,11 +89,6 @@ describe Fortnox::API::Model::Base do
       let(:saved_entry) { Entity.new(string: 'Saved', new: false, unsaved: false) }
       let(:updated_entry) { saved_entry.update(string: 'Updated') }
 
-      before do
-        raise 'Entity expected to be new!' if saved_entry.new?
-        raise 'Entity not expected to be saved!' unless saved_entry.saved?
-      end
-
       describe 'returned entity' do
         subject { updated_entry }
 

--- a/spec/fortnox/api/models/examples/model.rb
+++ b/spec/fortnox/api/models/examples/model.rb
@@ -11,10 +11,11 @@ shared_examples_for 'a model' do |unique_id|
   describe '.unique_id' do
     subject { model.unique_id }
 
-    before { expect(model.send(unique_id_attribute)).to eq unique_id }
-
-    let(:attributes) { required_attributes.merge(unique_id_attribute => unique_id) }
-    let(:model) { described_class.new(attributes) }
+    let(:model) do
+      described_class.new(
+        required_attributes.merge(unique_id_attribute => unique_id)
+      )
+    end
 
     it { is_expected.to eq unique_id }
   end

--- a/spec/fortnox/api/repositories/base_spec.rb
+++ b/spec/fortnox/api/repositories/base_spec.rb
@@ -66,14 +66,20 @@ describe Fortnox::API::Repository::Base do
         subject { repository.next_access_token }
 
         before { Fortnox::API.configure { |conf| conf.access_token = access_token } }
+
         it { is_expected.to eql(access_token) }
+      end
 
-        describe 'next request' do
-          before { repository.next_access_token }
+      context 'with one access token and two subsequent requests' do
+        subject { repository.next_access_token }
 
-          it 'still uses the same token' do
-            is_expected.to eql(access_token)
-          end
+        before do
+          Fortnox::API.configure { |conf| conf.access_token = access_token }
+          repository.next_access_token
+        end
+
+        it 'still uses the same token' do
+          is_expected.to eql(access_token)
         end
       end
 

--- a/spec/fortnox/api/repositories/examples/save.rb
+++ b/spec/fortnox/api/repositories/examples/save.rb
@@ -40,12 +40,6 @@ shared_examples_for '.save' do |attribute, additional_attrs: {}|
         let(:hash) { { unsaved: false }.merge(new_hash) }
         let(:model) { described_class::MODEL.new(hash) }
 
-        before do
-          # Should not make an API request in test!
-          expect(repository).not_to receive(:save_new)
-          expect(repository).not_to receive(:update_existing)
-        end
-
         specify { expect(repository.save(model)).to be(true) }
       end
     end

--- a/spec/fortnox/api/types/house_work_types_spec.rb
+++ b/spec/fortnox/api/types/house_work_types_spec.rb
@@ -7,6 +7,7 @@ require 'fortnox/api/repositories/order'
 require 'fortnox/api/models/order'
 require 'fortnox/api/types/order_row'
 
+# rubocop:disable RSpec/DescribeClass
 describe 'HouseWorkTypes', integration: true do
   include Helpers::Configuration
 
@@ -19,7 +20,8 @@ describe 'HouseWorkTypes', integration: true do
   let(:order_row) do
     Fortnox::API::Types::OrderRow.new(ordered_quantity: 1,
                                       article_number: '0000',
-                                      house_work_type: house_work_type) end
+                                      house_work_type: house_work_type)
+  end
 
   shared_examples_for 'house work type' do |type, legacy: false|
     subject do

--- a/spec/support/helpers/dummy_class_helper.rb
+++ b/spec/support/helpers/dummy_class_helper.rb
@@ -18,9 +18,7 @@ module Helpers
 
       clean_up_dry_types
 
-      classes_created_by_block.each do |klass|
-        Object.send(:remove_const, klass)
-      end
+      classes_created_by_block.each { |klass| Object.send(:remove_const, klass) }
     end
   end
 

--- a/spec/support/matchers/type/have_nullable_date_matcher.rb
+++ b/spec/support/matchers/type/have_nullable_date_matcher.rb
@@ -45,15 +45,13 @@ module Matchers
         @klass.new(@attribute => @invalid_value)
 
         @failure_description << " (Expected #{@expected_error}, but got none)"
-        return false
+        false
       rescue @expected_error => error
-        if error.message == @expected_error_message
-          return true
-        else
-          fail_message = "Expected error message to include #{expected_message.inspect}, "\
-                         "but was #{error.message.inspect}"
-          raise(fail_message)
-        end
+        return true if error.message == @expected_error_message
+
+        fail_message = "Expected error message to include #{expected_message.inspect}, "\
+                       "but was #{error.message.inspect}"
+        raise(fail_message)
       end
     end
   end

--- a/spec/support/matchers/type/have_nullable_string_matcher.rb
+++ b/spec/support/matchers/type/have_nullable_string_matcher.rb
@@ -36,13 +36,11 @@ module Matchers
       rescue Fortnox::API::InvalidAttributeValueError => error
         expected_message = "#{non_string.inspect} (#{non_string.class}) "\
                            "has invalid type for #{@attribute.inspect}"
-        if error.message.include?(expected_message)
-          return true
-        else
-          fail_message = "Expected error message to include #{expected_message.inspect}, "\
-                         "but was #{error.message.inspect}"
-          raise(fail_message)
-        end
+        return true if error.message.include?(expected_message)
+
+        fail_message = "Expected error message to include #{expected_message.inspect}, "\
+                       "but was #{error.message.inspect}"
+        raise(fail_message)
       end
     end
   end

--- a/spec/support/matchers/type/require_attribute_matcher.rb
+++ b/spec/support/matchers/type/require_attribute_matcher.rb
@@ -44,12 +44,10 @@ module Matchers
       def includes_error_message
         @klass.new(@invalid_hash)
       rescue EXCEPTION => error
-        if error.message.include? expected_error_message
-          return true
-        else
-          @wrong_error_message = error.message
-          return false
-        end
+        return true if error.message.include? expected_error_message
+
+        @wrong_error_message = error.message
+        false
       end
 
       def expected_error_message


### PR DESCRIPTION
Some refactoring made to fix Rubocop violations. Note that this PR has `rubocop_update` as base.