### PR TITLE
Allow delivered_quantity to be negative

### DIFF
--- a/lib/fortnox/api/types/document_row.rb
+++ b/lib/fortnox/api/types/document_row.rb
@@ -20,7 +20,7 @@ module Fortnox
         attribute :cost_center, Types::Nullable::String
 
         # DeliveredQuantity Delivered quantity. 14 digits
-        attribute :delivered_quantity, Types::Sized::Float[0.0, 9_999_999_999_999.9]
+        attribute :delivered_quantity, Types::Sized::Float[-9_999_999_999_999.9, 9_999_999_999_999.9]
 
         # Description Description Row description. 50 characters
         attribute :description, Types::Sized::String[50]

--- a/spec/fortnox/api/types/examples/document_row.rb
+++ b/spec/fortnox/api/types/examples/document_row.rb
@@ -6,12 +6,20 @@ shared_examples_for 'DocumentRow' do |valid_hash|
   it { is_expected.to have_sized_string(:article_number, 50, valid_hash) }
   it { is_expected.to have_sized_string(:description, 50, valid_hash) }
 
-  it { is_expected.to have_sized_float(:delivered_quantity, 0.0, 9_999_999_999_999.9, valid_hash) }
-  it { is_expected.to have_sized_float(:price, 0.0, 99_999_999_999.9, valid_hash) }
-
   it { is_expected.to have_discount_type(:discount_type, valid_hash) }
 
   it { is_expected.to have_sized_integer(:housework_hours_to_report, 0, 99_999, valid_hash) }
 
   it { is_expected.to have_housework_type(:housework_type, valid_hash) }
+
+  it { is_expected.to have_sized_float(:price, 0.0, 99_999_999_999.9, valid_hash) }
+
+  it do
+    is_expected.to have_sized_float(
+      :delivered_quantity,
+      -9_999_999_999_999.9,
+      9_999_999_999_999.9,
+      valid_hash
+    )
+  end
 end


### PR DESCRIPTION
Hi,

Many thanks for the gem, it's really useful.

I updated `delivered_quantity` attribute of the `DocumentRow` so it can be negative as well as over 9000.

Here is a real world example of why this is needed. When working with Systembolaget, we sometimes receive claims on goods that were sent by mistake, damaged during shipment etc. We have to include the claim sum on the next invoice, it looks like an invoice row with negative quantity. Fortnox allows it from the web version, and I believe it shouldn't be prohibited by the API wrapper.

Please review the changes and let me know if you have any questions or objections.

Cheers 🖖 